### PR TITLE
[#171179889] add backend status check

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ following contents:
     "COSMOSDB_URI": "<COSMOSDB_URI>",
     "WEBHOOK_CHANNEL_URL": "<WEBHOOK_URL>",
     "QueueStorageConnection": "<QUEUES_STORAGE_CONNECTION_STRING>",
+    "AssetsStorageConnection": "<ASSETS_STORAGE_CONNECTION_STRING>",
+    "STATUS_ENDPOINT_URL": "<APP_BACKEND_INFO_ENDPOINT>",
+    "STATUS_REFRESH_INTERVAL_MS": "<STATUS_REFRESH_INTERVAL_MS>",
     "SUBSCRIPTIONS_FEED_TABLE": "SubscriptionsFeedByDay"
   },
   "ConnectionStrings": {}

--- a/StoreBakendStatus/function.json
+++ b/StoreBakendStatus/function.json
@@ -1,0 +1,18 @@
+{
+  "bindings": [
+    {
+      "schedule": "0 */5 * * * *",
+      "name": "storeBackendStatusTimer",
+      "type": "timerTrigger",
+      "direction": "in"
+    },
+    {
+      "type": "blob",
+      "name": "backendStatus",
+      "path": "status/backend.json",
+      "connection": "AssetsStorageConnection",
+      "direction": "out"
+    }
+  ],
+  "scriptFile": "../dist/StoreBackendStatus/index.js"
+}

--- a/StoreBakendStatus/index.ts
+++ b/StoreBakendStatus/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Store backend uptime status info into a static JSON
+ * stored into a blob storage served by a public CDN.
+ *
+ */
 import { Context } from "@azure/functions";
 import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
 import { get } from "superagent";

--- a/StoreBakendStatus/index.ts
+++ b/StoreBakendStatus/index.ts
@@ -1,0 +1,28 @@
+import { Context } from "@azure/functions";
+import { getRequiredStringEnv } from "io-functions-commons/dist/src/utils/env";
+import { get } from "superagent";
+
+const statusEndpointUrl = getRequiredStringEnv("STATUS_ENDPOINT_URL");
+const refreshIntervalMs = getRequiredStringEnv("STATUS_REFRESH_INTERVAL_MS");
+
+type IStoreBackendStatusHandler = (context: Context) => Promise<void>;
+
+export function StoreBackendStatusHandler(): IStoreBackendStatusHandler {
+  return async context => {
+    // fetch backend info endpoint
+    const backendInfoJson = await get(statusEndpointUrl)
+      .timeout(10000)
+      .accept("json")
+      .then(res => res.body);
+
+    // store the json into the blob storage
+    // tslint:disable-next-line:no-object-mutation
+    context.bindings.backendStatus = {
+      ...backendInfoJson,
+      last_update: new Date().toISOString(),
+      refresh_interval: refreshIntervalMs
+    };
+  };
+}
+
+export default StoreBackendStatusHandler;


### PR DESCRIPTION
Adds a time trigger (scheduled) functions that every 5 minutes saves the status check of the App backend (/info endpoint) to a static JSON into blob storage