### PR TITLE
[#172067300] Store single SpID Request/Response blob for logs

### DIFF
--- a/StoreSpidLogs/__test__/index.test.ts
+++ b/StoreSpidLogs/__test__/index.test.ts
@@ -17,10 +17,10 @@ const today = format(new Date(), "YYYY-MM-DD");
 const aSpidBlobItem: SpidBlobItem = {
   createdAt: new Date(),
   ip: "192.168.1.6" as IPString,
-  payload:
-    "<?xml version='1.0' encoding='UTF-8'?><note ID='AAAA_BBBB'><to>Azure</to><from>Azure</from><heading>Reminder</heading><body>New append from local dev</body></note>",
-  // tslint:disable-next-line: prettier
-  payloadType: "REQUEST" as "REQUEST" | "RESPONSE",
+  requestPayload:
+    "<?xml version='1.0' encoding='UTF-8'?><note ID='AAAA_BBBB'><to>Azure</to><from>Azure</from><heading>Reminder</heading><body>New append from local dev - REQUEST</body></note>",
+  responsePayload:
+    "<?xml version='1.0' encoding='UTF-8'?><note ID='AAAA_BBBB'><to>Azure</to><from>Azure</from><heading>Reminder</heading><body>New append from local dev - RESPONSE</body></note>",
   spidRequestId: "AAAA_BBBB"
 };
 
@@ -29,10 +29,10 @@ const aSpidMsgItem: SpidMsgItem = {
   createdAtDay: today,
   fiscalCode: aFiscalCode,
   ip: "192.168.1.6" as IPString,
-  payload:
-    "<?xml version='1.0' encoding='UTF-8'?><note ID='AAAA_BBBB'><to>Azure</to><from>Azure</from><heading>Reminder</heading><body>New append from local dev</body></note>",
-  // tslint:disable-next-line: prettier
-  payloadType: "REQUEST" as "REQUEST" | "RESPONSE",
+  requestPayload:
+    "<?xml version='1.0' encoding='UTF-8'?><note ID='AAAA_BBBB'><to>Azure</to><from>Azure</from><heading>Reminder</heading><body>New append from local dev - REQUEST</body></note>",
+  responsePayload:
+    "<?xml version='1.0' encoding='UTF-8'?><note ID='AAAA_BBBB'><to>Azure</to><from>Azure</from><heading>Reminder</heading><body>New append from local dev - RESPONSE</body></note>",
   spidRequestId: "AAAA_BBBB"
 };
 
@@ -65,7 +65,7 @@ describe("StoreSpidLogs", () => {
       }
     };
     const blobItem = await index(mockedContext as any, aSpidMsgItem);
-    expect(blobItem).toEqual({ spidRequest: aSpidBlobItem });
+    expect(blobItem).toEqual({ spidRequestResponse: aSpidBlobItem });
   });
 
   it("should store a SPID response published into the queue", async () => {
@@ -79,13 +79,11 @@ describe("StoreSpidLogs", () => {
       }
     };
     const blobItem = await index(mockedContext as any, {
-      ...aSpidMsgItem,
-      payloadType: "RESPONSE"
+      ...aSpidMsgItem
     });
     expect(blobItem).toEqual({
-      spidResponse: {
-        ...aSpidBlobItem,
-        payloadType: "RESPONSE"
+      spidRequestResponse: {
+        ...aSpidBlobItem
       }
     });
   });

--- a/StoreSpidLogs/function.json
+++ b/StoreSpidLogs/function.json
@@ -6,19 +6,11 @@
       "name": "spidMsgItem",
       "type": "queueTrigger",
       "direction": "in"
-    }
-    ,
-    {
-      "type": "blob",
-      "name": "spidRequest",
-      "path": "spidassertions/{spidRequestId}-{payloadType}-{createdAtDay}.json",
-      "connection": "LogStorageConnection",
-      "direction": "out"
     },
     {
       "type": "blob",
-      "name": "spidResponse",
-      "path": "spidassertions/{spidRequestId}-{payloadType}-{createdAtDay}-{fiscalCode}.json",
+      "name": "spidRequestResponse",
+      "path": "spidassertions/{spidRequestId}-{createdAtDay}-{fiscalCode}.json",
       "connection": "LogStorageConnection",
       "direction": "out"
     }

--- a/StoreSpidLogs/index.ts
+++ b/StoreSpidLogs/index.ts
@@ -17,11 +17,11 @@ const SpidBlobItem = t.interface({
   // IP of the client that made a SPID login action
   ip: IPString,
 
-  // XML payload of the SPID Request/Response
-  payload: t.string,
+  // XML payload of the SPID Request
+  requestPayload: t.string,
 
-  // Payload type: REQUEST or RESPONSE
-  payloadType: t.keyof({ REQUEST: null, RESPONSE: null }),
+  // XML payload of the SPID Response
+  responsePayload: t.string,
 
   // SPID request ID
   spidRequestId: t.string
@@ -54,9 +54,11 @@ const contextTransport = new AzureContextTransport(() => logger, {
 });
 winston.add(contextTransport);
 
-type OutputBinding =
-  | { spidResponse: SpidBlobItem }
-  | { spidRequest: SpidBlobItem };
+const OutputBinding = t.interface({
+  spidRequestResponse: SpidBlobItem
+});
+
+export type OutputBinding = t.TypeOf<typeof OutputBinding>;
 
 /**
  * Store SPID request / responses, read from a queue, into a blob storage.
@@ -78,9 +80,10 @@ export async function index(
           )}`
         );
       },
-      spidBlobItem =>
-        spidMsgItem.payloadType === "RESPONSE"
-          ? { spidResponse: spidBlobItem }
-          : { spidRequest: spidBlobItem }
+      spidBlobItem => {
+        return {
+          spidRequestResponse: spidBlobItem
+        };
+      }
     );
 }


### PR DESCRIPTION
It contains a refactor of SpidMsgItem, in order to include SPID request and response in the same message and store it to a single blob