### PR TITLE
[#172123296] pipeline support to deploy using staging slot

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,28 +6,68 @@
 # - DANGER_GITHUB_API_TOKEN
 #
 # To enable the deployment in any environment you need to configure the following 
-# variable otherwise all the deployment jobs will be always skipped:
+# global variable otherwise all the deployment jobs will be always skipped:
 # - DO_DEPLOY = true
-# in case of a manual run, you also need to configure the following additional 
-# variables based on the environment to update:
-# - STAGING_ENABLE_MANUAL_DEPLOY = true
-# - PRODUCTION_ENABLE_MANUAL_DEPLOY = true
+# you also need to configure the following additional parameters based on the 
+# environment(s) to update when running the pipeline:
+# - PRODUCTION_ENABLE_DEPLOY = true
+# - TEST_ENABLE_DEPLOY = true
 #
-# The following variables are also used when running the deployment jobs:
-# - STAGING_DEPLOY_MODE: 'deploy_standard' || 'deploy_to_slots'
-# - STAGING_AZURE_SUBSCRIPTION
-# - STAGING_RESOURCE_GROUP_NAME
-# - STAGING_FUNCTION_APP_NAME
-# 
-# - PRODUCTION_DEPLOY_MODE: 'deploy_standard' || 'deploy_to_slots'
+# The following parameter and variables must also be set to run the deployment:
+# - PRODUCTION_DEPLOY_TYPE:
+#    -- 'deployToStagingSlot': deploy to 'staging' slot 
+#    -- 'deployToProductionSlot' (default): deploy to 'production' slot
+#    -- 'deployToStagingSlotAndSwap': deploy to 'staging' slot and then swap 
 # - PRODUCTION_AZURE_SUBSCRIPTION
 # - PRODUCTION_RESOURCE_GROUP_NAME
-# - PRODUCTION_FUNCTION_APP_NAME
+# - PRODUCTION_APP_NAME
 #
+# - TEST_DEPLOY_TYPE:
+#      -- 'deployToTestSlot' (default): deploy to 'test' slot 
+#      -- 'deployToProductionSlot': deploy to 'production' slot (TEST env)
+# - TEST_AZURE_SUBSCRIPTION
+# - TEST_RESOURCE_GROUP_NAME
+# - TEST_APP_NAME
+# 
+# Please note that the deployment to a slot (e.g. 'staging') could automatically
+# trigger the swapping with 'production' slot if "auto swap" has been enabled in
+# the App service configuration. This also means that if the "auto swap" is on and 
+# you select 'deployToStagingSlotAndSwap' to swap 'staging' and 'production' slots
+# after deploying to 'staging', the swap task in this pipeline will probably fail
+# because conflicting with another (automatic) swap operation in progress.
+# 
 
 variables:
   NODE_VERSION: '10.14.1'
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
+parameters:
+  - name: 'TEST_ENABLE_DEPLOY'
+    displayName: 'Enable deploy in test environment'
+    type: boolean
+    default: false
+
+  - name: 'TEST_DEPLOY_TYPE'
+    displayName: 'Method to achieve deployment in Test (if enabled):'
+    type: string
+    default: deployToTestSlot
+    values:
+      - deployToTestSlot  
+      - deployToProductionSlot
+
+  - name: 'PRODUCTION_ENABLE_DEPLOY'
+    displayName: 'Enable deploy in production environment'
+    type: boolean
+    default: true
+
+  - name: 'PRODUCTION_DEPLOY_TYPE'
+    displayName: 'Method to achieve deployment in Production (if enabled):'
+    type: string
+    default: deployToProductionSlot
+    values:
+      - deployToStagingSlot  
+      - deployToProductionSlot
+      - deployToStagingSlotAndSwap
 
 # This pipeline can be manually run or is automatically triggered whenever one 
 # of the following conditions is true:
@@ -45,7 +85,8 @@ trigger:
 # This pipeline has been implemented to be run on hosted agent pools based both
 # on 'windows' and 'ubuntu' virtual machine images and using the scripts defined
 # in the package.json file. Since we are deploying on Azure functions on Windows
-# runtime, the pipeline is currently configured to use a Windows hosted image.
+# runtime, the pipeline is currently configured to use a Windows hosted image for
+# the build and deploy.
 pool:
   vmImage: 'windows-2019'
 
@@ -128,113 +169,67 @@ stages:
           displayName: 'Code coverage'
 
 
-  # C) Deploy to STAGE environment if the following conditions apply:
+  # C) Deploy to TEST environment if the following conditions apply:
   #    - continuos deployment (automatic):
-  #       - $DO_DEPLOY == true and
+  #       - $DO_DEPLOY == true and TEST_ENABLE_DEPLOY == true
   #       - there is a push on 'master' branch 
   #    - manual deployment:
-  #       - $DO_DEPLOY == true and
-  #       - $STAGING_ENABLE_MANUAL_DEPLOY == true
-  # The following alternative deployment modes are supported:
-  #   a) $STAGING_DEPLOY_MODE == 'deploy_standard': deploy to 'prodution' slot
-  #   b) $STAGING_DEPLOY_MODE == 'deploy_to_slots': deploy to 'staging' slot and
-  #      then swap 'staging' slot with 'production' slot
-  - stage: Deploy_staging
-    condition: 
-      and(
-        succeeded(),
-        and (
-          eq(variables['DO_DEPLOY'], true),
-          or(
-            and(
+  #       - $DO_DEPLOY == true and TEST_ENABLE_DEPLOY == true
+  - ${{ if eq(parameters.TEST_ENABLE_DEPLOY, true) }}:
+    - stage: Deploy_test
+      condition: 
+        and(
+          succeeded(),
+          and (
+            eq(variables['DO_DEPLOY'], true),
+            or(
               eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-              ne(variables['Build.Reason'], 'Manual')
-            ),
-            and(
-              eq(variables['STAGING_ENABLE_MANUAL_DEPLOY'], true),
               eq(variables['Build.Reason'], 'Manual')
             )
           )
-        )
-      )
-    dependsOn:
-    - Build
-    - Test
-    jobs:
-      # Option 1: deploy directly to 'production' slot
-      - job: deploy_standard
-        condition: and(succeeded(), eq(variables['STAGING_DEPLOY_MODE'], 'deploy_standard'))
-        steps:
-        - template: azure-templates/deploy-steps.yml
-          parameters:
-            deployType: 'deployToProductionSlot'
-            azureSubscription: '$(STAGING_AZURE_SUBSCRIPTION)'
-            resourceGroupName: '$(STAGING_RESOURCE_GROUP_NAME)'
-            appName: '$(STAGING_FUNCTION_APP_NAME)'
-
-      # Option 2: deploy to staging slot and then swap with 'production' slot
-      - job: deploy_to_slots
-        condition: and(succeeded(), eq(variables['STAGING_DEPLOY_MODE'], 'deploy_to_slots'))
-        steps:
-        - template: azure-templates/deploy-steps.yml
-          parameters:
-            deployType: 'deployToStagingSlotAndSwap'
-            azureSubscription: '$(STAGING_AZURE_SUBSCRIPTION)'
-            resourceGroupName: '$(STAGING_RESOURCE_GROUP_NAME)'
-            appName: '$(STAGING_FUNCTION_APP_NAME)'
+        )    
+      dependsOn:
+        - Build
+        - Test
+      jobs:
+        - job: '${{ parameters.TEST_DEPLOY_TYPE }}'
+          steps:
+          - template: azure-templates/deploy-steps.yml
+            parameters:
+              deployType: '${{ parameters.TEST_DEPLOY_TYPE }}'
+              azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
+              resourceGroupName: '$(TEST_RESOURCE_GROUP_NAME)'
+              appName: '$(TEST_APP_NAME)'
 
 
   # D) Deploy to PRODUCTION environment if one of the following conditions apply:
   #    - continuos deployment (automatic):
-  #       - $DO_DEPLOY == true and
+  #       - $DO_DEPLOY == true and PRODUCTION_ENABLE_DEPLOY == true
   #       - the 'latest' tag is pushed 
   #    - manual deployment:
-  #       - $DO_DEPLOY == true and
-  #       - $PRODUCTION_ENABLE_MANUAL_DEPLOY == true
-  # The following alternative deployment modes are supported:
-  #   a) $PRODUCTION_DEPLOY_MODE == 'deploy_standard': deploy to 'prodution' slot
-  #   b) $PRODUCTION_DEPLOY_MODE == 'deploy_to_slots': deploy to 'staging' slot and
-  #      then swap 'staging' slot with 'production' slot
-  - stage: Deploy_production
-    condition: 
-      and(
-        succeeded(),
-        and (
-          eq(variables['DO_DEPLOY'], true),
-          or(
-            and(
+  #       - $DO_DEPLOY == true and PRODUCTION_ENABLE_DEPLOY == true
+  - ${{ if eq(parameters.PRODUCTION_ENABLE_DEPLOY, true) }}:
+    - stage: Deploy_production
+      condition: 
+        and(
+          succeeded(),
+          and (
+            eq(variables['DO_DEPLOY'], true),
+            or(
               eq(variables['Build.SourceBranch'], 'refs/tags/latest'),
-              ne(variables['Build.Reason'], 'Manual')
-            ),
-            and(
-              eq(variables['PRODUCTION_ENABLE_MANUAL_DEPLOY'], true),
               eq(variables['Build.Reason'], 'Manual')
             )
           )
         )
-      )
-    dependsOn:
-    - Build
-    - Test
-    jobs:
-      # Option 1: deploy directly to 'production' slot
-      - job: deploy_standard
-        condition: and(succeeded(), eq(variables['PRODUCTION_DEPLOY_MODE'], 'deploy_standard'))
-        steps:
-        - template: azure-templates/deploy-steps.yml
-          parameters:
-            deployType: 'deployToProductionSlot'
-            azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
-            resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
-            appName: '$(PRODUCTION_FUNCTION_APP_NAME)'
-
-      # Option 2: deploy to staging slot and then swap with 'production' slot
-      - job: deploy_to_slots
-        condition: and(succeeded(), eq(variables['PRODUCTION_DEPLOY_MODE'], 'deploy_to_slots'))
-        steps:
-        - template: azure-templates/deploy-steps.yml
-          parameters:
-            deployType: 'deployToStagingSlotAndSwap'
-            azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
-            resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
-            appName: '$(PRODUCTION_FUNCTION_APP_NAME)'
+      dependsOn:
+        - Build
+        - Test
+      jobs:
+        - job: '${{ parameters.PRODUCTION_DEPLOY_TYPE }}'
+          steps:
+          - template: azure-templates/deploy-steps.yml
+            parameters:
+              deployType: '${{ parameters.PRODUCTION_DEPLOY_TYPE }}'
+              azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
+              resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
+              appName: '$(PRODUCTION_APP_NAME)'

--- a/azure-templates/deploy-steps.yml
+++ b/azure-templates/deploy-steps.yml
@@ -3,100 +3,116 @@
 # Note. Deployment slots let you deploy different versions of your function
 # app to different URLs. You can test a certain version and then swap content
 # and configuration between slots to have minimal impact to production and also 
-# make rollback easily.
+# make rollback easily.
 
 parameters:
-- name: 'deployType'
-  type: string
-  default: deployToProductionSlot
-  values:
-  - deployToProductionSlot
-  - deployToStagingSlotAndSwap
-  - deployToStagingSlot  
-
-- name: 'azureSubscription'
-  type: string
-  default: ''
-
-- name: 'resourceGroupName'
-  type: string
-  default: ''
-
-- name: 'appName'
-  type: string
-  default: ''
+  - name: 'deployType'
+    type: string
+    default: deployToProductionSlot
+    values:
+    - deployToProductionSlot
+    - deployToStagingSlotAndSwap
+    - deployToStagingSlot  
+    - deployToTestSlot  
   
-steps:
-- template: ./make-build-steps.yml
-  parameters:
-    make: predeploy_build
-
-- task: CopyFiles@2
-  inputs:
-    SourceFolder: '$(System.DefaultWorkingDirectory)'
-    TargetFolder: '$(Build.ArtifactStagingDirectory)'
-    Contents: |
-      **/*
-      !.git/**/*
-      !**/*.js.map
-      !**/*.ts
-      !.vscode/**/*
-      !azure-templates/**/*
-      !azure-pipelines.yml
-      !.prettierrc
-      !.gitignore
-      !README.md
-      !jest.config.js
-      !local.settings.json
-      !test
-      !tsconfig.json
-  displayName: 'Copy deploy files'
-
-# Option 1: standard deployment without slots (i.e. deploy directly to main slot)
-- ${{ if eq(parameters.deployType, 'deployToProductionSlot') }}:
-  - task: AzureFunctionApp@1
-    inputs:
-      azureSubscription: '${{ parameters.azureSubscription }}'
-      resourceGroupName: '${{ parameters.resourceGroupName }}'
-      appType: 'functionApp'
-      appName: '${{ parameters.appName }}'
-      package: '$(Build.ArtifactStagingDirectory)/'
-      deploymentMethod: 'auto'
-    displayName: Direct deploy
-
-# Option 2: deployment to 'staging' slot only (not used)
-- ${{ if eq(parameters.deployType, 'deployToStagingSlot') }}:
-  - task: AzureFunctionApp@1
-    inputs:
-      azureSubscription: '${{ parameters.azureSubscription }}'
-      resourceGroupName: '${{ parameters.resourceGroupName }}'
-      appType: 'functionApp'
-      appName: '${{ parameters.appName }}'
-      package: '$(Build.ArtifactStagingDirectory)/'
-      deploymentMethod: 'auto'
-      deployToSlotOrASE: true
-      slotName: 'staging'
-    displayName: Deploy to staging slot only
-
-# Option 3: deployment with two slots ('staging' and 'production')
-- ${{ if eq(parameters.deployType, 'deployToStagingSlotAndSwap') }}:
-  - task: AzureFunctionApp@1  # First step: deploy to 'staging' slot 
-    inputs:
-      azureSubscription: '${{ parameters.azureSubscription }}'
-      resourceGroupName: '${{ parameters.resourceGroupName }}'
-      appType: 'functionApp'
-      appName: '${{ parameters.appName }}'
-      package: '$(Build.ArtifactStagingDirectory)/'
-      deploymentMethod: 'auto'
-      deployToSlotOrASE: true
-      slotName: 'staging'
-    displayName: Deploy to staging slot
+  - name: 'azureSubscription'
+    type: string
+    default: ''
+  
+  - name: 'resourceGroupName'
+    type: string
+    default: ''
+  
+  - name: 'appName'
+    type: string
+    default: ''
     
-  - task: AzureAppServiceManage@0   # Second step: swap 'staging' with 'production' slot
+steps:
+  - template: ./make-build-steps.yml
+    parameters:
+      make: predeploy_build
+  
+  - task: CopyFiles@2
     inputs:
-      azureSubscription: '${{ parameters.azureSubscription }}'
-      resourceGroupName: '${{ parameters.resourceGroupName }}'
-      webAppName: '${{ parameters.appName }}'
-      sourceSlot: staging
-      swapWithProduction: true
-    displayName: Swap with production slot
+      SourceFolder: '$(System.DefaultWorkingDirectory)'
+      TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      Contents: |
+        **/*
+        !.git/**/*
+        !**/*.js.map
+        !**/*.ts
+        !.vscode/**/*
+        !azure-templates/**/*
+        !azure-pipelines.yml
+        !.prettierrc
+        !.gitignore
+        !README.md
+        !jest.config.js
+        !local.settings.json
+        !test
+        !tsconfig.json
+    displayName: 'Copy deploy files'
+  
+  # Option 1: standard deployment without slots (i.e. deploy directly to main slot)
+  - ${{ if eq(parameters.deployType, 'deployToProductionSlot') }}:
+    - task: AzureFunctionApp@1
+      inputs:
+        azureSubscription: '${{ parameters.azureSubscription }}'
+        resourceGroupName: '${{ parameters.resourceGroupName }}'
+        appType: 'functionApp'
+        appName: '${{ parameters.appName }}'
+        package: '$(Build.ArtifactStagingDirectory)/'
+        deploymentMethod: 'auto'
+      displayName: Deploy to production slot
+  
+  # Option 2: deployment to 'staging' slot only
+  - ${{ if eq(parameters.deployType, 'deployToStagingSlot') }}:
+    - task: AzureFunctionApp@1
+      inputs:
+        azureSubscription: '${{ parameters.azureSubscription }}'
+        resourceGroupName: '${{ parameters.resourceGroupName }}'
+        appType: 'functionApp'
+        appName: '${{ parameters.appName }}'
+        package: '$(Build.ArtifactStagingDirectory)/'
+        deploymentMethod: 'auto'
+        deployToSlotOrASE: true
+        slotName: 'staging'
+      displayName: Deploy to staging slot only
+  
+  # Option 3: deployment with two slots ('staging' and 'production')
+  - ${{ if eq(parameters.deployType, 'deployToStagingSlotAndSwap') }}:
+    - task: AzureFunctionApp@1  # First step: deploy to 'staging' slot 
+      inputs:
+        azureSubscription: '${{ parameters.azureSubscription }}'
+        resourceGroupName: '${{ parameters.resourceGroupName }}'
+        appType: 'functionApp'
+        appName: '${{ parameters.appName }}'
+        package: '$(Build.ArtifactStagingDirectory)/'
+        deploymentMethod: 'auto'
+        deployToSlotOrASE: true
+        slotName: 'staging'
+      displayName: Deploy to staging slot
+      
+    - task: AzureAppServiceManage@0   # Second step: swap 'staging' with 'production' slot
+      inputs:
+        azureSubscription: '${{ parameters.azureSubscription }}'
+        resourceGroupName: '${{ parameters.resourceGroupName }}'
+        webAppName: '${{ parameters.appName }}'
+        sourceSlot: staging
+        swapWithProduction: true
+      displayName: Swap with production slot
+  
+  # Option 4: deployment to 'test' slot only
+  - ${{ if eq(parameters.deployType, 'deployToTestSlot') }}:
+    - task: AzureFunctionApp@1
+      inputs:
+        azureSubscription: '${{ parameters.azureSubscription }}'
+        resourceGroupName: '${{ parameters.resourceGroupName }}'
+        appType: 'functionApp'
+        appName: '${{ parameters.appName }}'
+        package: '$(Build.ArtifactStagingDirectory)/'
+        deploymentMethod: 'auto'
+        deployToSlotOrASE: true
+        slotName: 'test'
+      displayName: Deploy to staging slot only
+  


### PR DESCRIPTION
The following changes have been implemented in the Azure DevOps pipeline to address zero downtime & fast rollback in production:
- added support for selecting one of the following deployment methods in **production** environment:
    - '_deployToStagingSlot_': deploy to 'staging' slot 
    - '_deployToProductionSlot_' (**current default**): deploy to 'production' slot (_preconfigured slot_)
    - '_deployToStagingSlotAndSwap_': deploy to 'staging' slot and then swap 'staging' with 'production' 

    **Note 1**. The default value is now set to _deployToProductionSlot_ to allow developers to continuously deploy in the current infrastructure (without slots). We can change the default to _deployToStagingSlot_ when the 'staging' slot with 'auto swap' on will be available.  

    **Note 2**.  The deployment to a slot (e.g. 'staging') could automatically trigger the swapping with 'production' slot if "auto swap" will be enabled in the App service configuration. This also means that if the "auto swap" is on and you select 'deployToStagingSlotAndSwap' to swap 'staging' and 'production' slots after deploying to 'staging', the swap task in this pipeline will fail because conflicting with another (automatic) swap operation in progress.   

- [**not used**] added for experimental purpose only the support for the following deployment methods in **test** environment (now not available):
    - 'deployToTestSlot' (default): deploy to 'test' slot (it could be a third slot of the same services used in production)
    - 'deployToProductionSlot': deploy to 'production' slot (it could be used in case the TEST environment would be based on separate and dedicated services)

    **Note 3**. Today we still do not have a test environment and for this reason the deployment in the test environment is currently disabled by default. The definition of this environment, useful for executing integration tests, is a work in progress but the idea is to have a separate and dedicated slot ('slot').

- improved our Azure pipeline with the new **Runtime Parameters** to make it easier and faster to set some configuration settings that can be passed when manually running the pipeline; e.g. now you can select the deployment environment and mode directly in the main "Run pipeline" panel of the Azure DevOps portal (the previous pipeline  took you three clicks to modify a single value for every single variable and for every run):

  <img width="426" alt="Screenshot 2020-04-02 at 17 02 21" src="https://user-images.githubusercontent.com/60641726/78266167-b29ad800-7505-11ea-808a-fb92267fa400.png">
