### PR TITLE
[#172734823] - Retry on send welcome messages activity

### DIFF
--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -147,9 +147,13 @@ export const handler = function*(
   );
 
   if (hasJustEnabledInbox) {
-    yield context.df.callActivity("SendWelcomeMessagesActivity", {
-      profile: newProfile
-    });
+    yield context.df.callActivityWithRetry(
+      "SendWelcomeMessagesActivity",
+      retryOptions,
+      {
+        profile: newProfile
+      }
+    );
   }
 
   // Update subscriptions feed


### PR DESCRIPTION
SendWelcomeMessageActivity must implement azure durable functions retry options in order to manage errors ( and retry welcome messages send in that case ).