### PR TITLE
Upgrades typescript to 3.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "shx": "^0.3.2",
     "ts-jest": "^24.0.2",
     "tslint": "^5.17.0",
-    "typescript": "^3.6.2"
+    "typescript": "^3.9.5"
   },
   "dependencies": {
     "abort-controller": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8533,10 +8533,10 @@ typedoc@^0.17.1:
     shelljs "^0.8.4"
     typedoc-default-themes "^0.10.1"
 
-typescript@^3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+typescript@^3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 typestrict@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Gets rid of the following warning:

```
warning "durable-functions > typedoc@0.17.7" has incorrect peer dependency "typescript@>=3.8.3".
```