### PR TITLE
[#174877080] Change subscription key header

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -346,7 +346,7 @@ produces:
 securityDefinitions:
   SubscriptionKey:
     type: apiKey
-    name: Ocp-Apim-Subscription-Key
+    name: X-Functions-Key
     in: header
     description: The API key obtained through the developer portal.
 parameters:


### PR DESCRIPTION
While working at [this](https://github.com/pagopa/io-backend/pull/711) we noticed that the `SubscriptionKey` is referencing the wrong header field.