### PR TITLE
[#175126219] Healthcheck step in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ parameters:
   - name: 'PRODUCTION_DEPLOY_TYPE'
     displayName: 'Method to achieve deployment in Production (if enabled):'
     type: string
-    default: deployToStagingSlot
+    default: deployToStagingSlotAndSwap
     values:
       - deployToStagingSlot  
       - deployToProductionSlot

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,7 +245,7 @@ stages:
               azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
               resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
               appName: '$(PRODUCTION_APP_NAME)'
-              healthcheckEndpoint: 'https://$(PRODUCTION_APP_NAME).staging.azurewebsites.net/info'
+              healthcheckEndpoint: 'https://$(PRODUCTION_APP_NAME)-staging.azurewebsites.net/api/v1/info'
               containerInstanceResourceGroup: 'io-p-rg-common'
               containerInstanceVNet: 'io-p-vnet-common'
               containerInstanceSubnet: 'azure-devops'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,14 @@ trigger:
 pool:
   vmImage: 'windows-2019'
 
+resources:
+  repositories:
+    - repository: pagopaCommons
+      type: github
+      name: pagopa/azure-pipeline-templates
+      ref: refs/tags/v1
+      endpoint: 'pagopa'  
+
 stages:
   # A) Build and code validation
   - stage: Build
@@ -200,6 +208,10 @@ stages:
               azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
               resourceGroupName: '$(TEST_RESOURCE_GROUP_NAME)'
               appName: '$(TEST_APP_NAME)'
+              healthcheckEndpoint: 'https://$(TEST_APP_NAME).staging.azurewebsites.net/info'
+              containerInstanceResourceGroup: 'io-p-rg-common'
+              containerInstanceVNet: 'io-p-vnet-common'
+              containerInstanceSubnet: 'azure-devops'
 
 
   # D) Deploy to PRODUCTION environment if one of the following conditions apply:
@@ -233,3 +245,7 @@ stages:
               azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'
               resourceGroupName: '$(PRODUCTION_RESOURCE_GROUP_NAME)'
               appName: '$(PRODUCTION_APP_NAME)'
+              healthcheckEndpoint: 'https://$(PRODUCTION_APP_NAME).staging.azurewebsites.net/info'
+              containerInstanceResourceGroup: 'io-p-rg-common'
+              containerInstanceVNet: 'io-p-vnet-common'
+              containerInstanceSubnet: 'azure-devops'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -208,7 +208,7 @@ stages:
               azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
               resourceGroupName: '$(TEST_RESOURCE_GROUP_NAME)'
               appName: '$(TEST_APP_NAME)'
-              healthcheckEndpoint: 'https://$(TEST_APP_NAME).staging.azurewebsites.net/info'
+              healthcheckEndpoint: 'https://$(TEST_APP_NAME)-staging.azurewebsites.net/api/v1/info'
               containerInstanceResourceGroup: 'io-p-rg-common'
               containerInstanceVNet: 'io-p-vnet-common'
               containerInstanceSubnet: 'azure-devops'

--- a/azure-templates/deploy-steps.yml
+++ b/azure-templates/deploy-steps.yml
@@ -26,6 +26,22 @@ parameters:
   - name: 'appName'
     type: string
     default: ''
+
+  # full endpoint to perform healthcheck against, 
+  - name: 'healthcheckEndpoint'
+    type: string
+
+  # the resource group must be the same where vnet is created
+  - name: 'containerInstanceResourceGroup'
+    type: string
+
+  # attached vnet to the container instance
+  - name: 'containerInstanceVNet'
+    type: string
+
+  # container instance subnet
+  - name: 'containerInstanceSubnet'
+    type: string
     
 steps:
   - template: ./make-build-steps.yml
@@ -87,7 +103,8 @@ steps:
   
   # Option 3: deployment with two slots ('staging' and 'production')
   - ${{ if eq(parameters.deployType, 'deployToStagingSlotAndSwap') }}:
-    - task: AzureFunctionApp@1  # First step: deploy to 'staging' slot 
+    # First step: deploy to 'staging' slot  
+    - task: AzureFunctionApp@1  
       inputs:
         azureSubscription: '${{ parameters.azureSubscription }}'
         resourceGroupName: '${{ parameters.resourceGroupName }}'
@@ -98,8 +115,19 @@ steps:
         deployToSlotOrASE: true
         slotName: 'staging'
       displayName: Deploy to staging slot
-      
-    - task: AzureAppServiceManage@0   # Second step: swap 'staging' with 'production' slot
+
+    # Second step: check the app is working
+    - template: templates/rest-healthcheck/template.yaml@pagopaCommons 
+      parameters:
+        azureSubscription: '${{ parameters.azureSubscription }}'
+        appName: '${{ parameters.appName }}'
+        endpoint: '${{ parameters.healthcheckEndpoint }}'
+        containerInstanceResourceGroup: '${{ parameters.containerInstanceResourceGroup }}'
+        containerInstanceVNet: '${{ parameters.containerInstanceVNet }}'
+        containerInstanceSubnet: '${{ parameters.containerInstanceSubnet }}'
+    
+    # Third step: swap 'staging' with 'production' slot  
+    - task: AzureAppServiceManage@0   
       inputs:
         azureSubscription: '${{ parameters.azureSubscription }}'
         resourceGroupName: '${{ parameters.resourceGroupName }}'


### PR DESCRIPTION
This PR introduces an healthcheck step just before promoting the staging slot to production. 

### Behaviour
* deploy application to Staging slot
* perform an http request against `/info` of the staging slot
* if the request is ok (code == 200)
  * switch slot with production
* else
  * abort the pipeline

### Implementation
The implementation relies on [this common template](https://github.com/pagopa/azure-pipeline-templates/tree/master/templates/rest-healthcheck). The important concept is the http request is performed by a separate container which needs some configuration, please refer to the template repository for further info.
