### PR TITLE
Added '@pagopa/' to package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "io-functions-app",
+  "name": "@pagopa/io-functions-app",
   "version": "1.40.1",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
In order to generate a correct client SDK, added @pagopa/ to the package name