### PR TITLE
Fix RPC error

### DIFF
--- a/host.json
+++ b/host.json
@@ -7,7 +7,8 @@
   },
   "extensions": {
     "durableTask": {
-      "hubName": "%SLOT_TASK_HUBNAME%"
+      "hubName": "%SLOT_TASK_HUBNAME%",
+      "localRpcEndpointEnabled": false
     }
   }
 }


### PR DESCRIPTION
With the default value (=true) the durable function extension use RPC call to 127.0.0.1 to comunicate withe the API exposed by the extension (for example to start a new orchestrator).
This behaviour sometime create problems, i already had a discussion with the product group here https://github.com/Azure/azure-functions-durable-extension/issues/1273#issuecomment-632219854.
Setting the value to false we use the old behaviour not using RPC. The difference is explained in this paragraph of the post above:

```
The side effect of this is to revert the durableClient to the old behavior of invoking the external-facing management APIs instead of using the internal ones on the local machine. In most cases, you should only notice a slight performance degradation for durableClient API calls.
```