### PR TITLE
Base step - Refactor for Notification Hub upgrade 

### DIFF
--- a/HandleNHNotificationCall/__tests__/index.test.ts
+++ b/HandleNHNotificationCall/__tests__/index.test.ts
@@ -1,0 +1,105 @@
+// tslint:disable:no-any
+
+import * as df from "durable-functions";
+import { DurableOrchestrationClient } from "durable-functions/lib/src/durableorchestrationclient";
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context } from "../../__mocks__/durable-functions";
+
+import { CreateOrUpdateInstallationMessage } from "../../generated/notifications/CreateOrUpdateInstallationMessage";
+import { DeleteInstallationMessage } from "../../generated/notifications/DeleteInstallationMessage";
+import { NotifyMessage } from "../../generated/notifications/NotifyMessage";
+import { PlatformEnum } from "../../generated/notifications/Platform";
+
+import { success } from "../../utils/activity";
+import HandleNHNotificationCall from "../index";
+
+const dfClient = ({
+  startNew: jest.fn().mockImplementation((_, __, ___) => success())
+} as any) as DurableOrchestrationClient;
+
+jest.spyOn(df, "getClient").mockReturnValue(dfClient);
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+const aPushChannel =
+  "fLKP3EATnBI:APA91bEy4go681jeSEpLkNqhtIrdPnEKu6Dfi-STtUiEnQn8RwMfBiPGYaqdWrmzJyXIh5Yms4017MYRS9O1LGPZwA4sOLCNIoKl4Fwg7cSeOkliAAtlQ0rVg71Kr5QmQiLlDJyxcq3p";
+
+const aDeleteInStalltionMessage: DeleteInstallationMessage = {
+  installationId: aFiscalCodeHash,
+  kind: "DeleteInstallation" as any
+};
+
+const aCreateOrUpdateInstallationMessage: CreateOrUpdateInstallationMessage = {
+  installationId: aFiscalCodeHash,
+  kind: "CreateOrUpdateInstallation" as any,
+  platform: PlatformEnum.apns,
+  pushChannel: aPushChannel,
+  tags: [aFiscalCodeHash]
+};
+
+const aNotifyMessage: NotifyMessage = {
+  installationId: aFiscalCodeHash,
+  kind: "Notify" as any,
+  payload: {
+    message: "message",
+    message_id: "id",
+    title: "title"
+  }
+};
+
+describe("HandleNHNotificationCall", () => {
+  it("should call Delete Orchestrator when message is DeleteInstallation", async () => {
+    await HandleNHNotificationCall(context as any, aDeleteInStalltionMessage);
+
+    expect(dfClient.startNew).toHaveBeenCalledWith(
+      "HandleNHNotificationCallOrchestrator",
+      undefined,
+      {
+        message: aDeleteInStalltionMessage
+      }
+    );
+  });
+
+  it("should call CreateOrUpdate Orchestrator when message is CreateorUpdateInstallation", async () => {
+    await HandleNHNotificationCall(
+      context as any,
+      aCreateOrUpdateInstallationMessage
+    );
+
+    expect(dfClient.startNew).toHaveBeenCalledWith(
+      "HandleNHNotificationCallOrchestrator",
+      undefined,
+      {
+        message: aCreateOrUpdateInstallationMessage
+      }
+    );
+  });
+
+  it("should call Notify Orchestrator when message is NotifyMessage", async () => {
+    await HandleNHNotificationCall(context as any, aNotifyMessage);
+
+    expect(dfClient.startNew).toHaveBeenCalledWith(
+      "HandleNHNotificationCallOrchestrator",
+      undefined,
+      {
+        message: aNotifyMessage
+      }
+    );
+  });
+
+  it("should not call any Orchestrator when message kind is not correct", async () => {
+    const aWrongMessage = {
+      installationId: aFiscalCodeHash,
+      kind: "WrongMessage" as any
+    };
+
+    // tslint:disable-next-line: no-let
+    let hasError = false;
+    try {
+      await HandleNHNotificationCall(context as any, aWrongMessage);
+    } catch (error) {
+      hasError = true;
+    }
+
+    expect(hasError).toBe(true);
+  });
+});

--- a/HandleNHNotificationCall/index.ts
+++ b/HandleNHNotificationCall/index.ts
@@ -34,32 +34,14 @@ export async function index(
   context: Context,
   notificationHubMessage: NotificationHubMessage
 ): Promise<void> {
+  const client = df.getClient(context);
   switch (notificationHubMessage.kind) {
     case DeleteKind.DeleteInstallation:
-      const client = df.getClient(context);
+    case CreateOrUpdateKind.CreateOrUpdateInstallation:
+    case NotifyKind.Notify:
       await client.startNew("HandleNHNotificationCallOrchestrator", undefined, {
         message: notificationHubMessage
       });
-      break;
-    case CreateOrUpdateKind.CreateOrUpdateInstallation:
-      const client2 = df.getClient(context);
-      await client2.startNew(
-        "HandleNHNotificationCallOrchestrator",
-        undefined,
-        {
-          message: notificationHubMessage
-        }
-      );
-      break;
-    case NotifyKind.Notify:
-      const client3 = df.getClient(context);
-      await client3.startNew(
-        "HandleNHNotificationCallOrchestrator",
-        undefined,
-        {
-          message: notificationHubMessage
-        }
-      );
       break;
     default:
       assertNever(notificationHubMessage);

--- a/HandleNHNotificationCall/index.ts
+++ b/HandleNHNotificationCall/index.ts
@@ -37,7 +37,17 @@ export async function index(
   const client = df.getClient(context);
   switch (notificationHubMessage.kind) {
     case DeleteKind.DeleteInstallation:
+      await client.startNew("HandleNHNotificationCallOrchestrator", undefined, {
+        message: notificationHubMessage
+      });
+      break;
+    // tslint:disable-next-line: no-duplicated-branches
     case CreateOrUpdateKind.CreateOrUpdateInstallation:
+      await client.startNew("HandleNHNotificationCallOrchestrator", undefined, {
+        message: notificationHubMessage
+      });
+      break;
+    // tslint:disable-next-line: no-duplicated-branches
     case NotifyKind.Notify:
       await client.startNew("HandleNHNotificationCallOrchestrator", undefined, {
         message: notificationHubMessage

--- a/utils/activity.ts
+++ b/utils/activity.ts
@@ -1,0 +1,61 @@
+import { Context } from "@azure/functions";
+import { toError } from "fp-ts/lib/Either";
+import * as t from "io-ts";
+
+// Activity result
+export const ActivityResultSuccess = t.interface({
+  kind: t.literal("SUCCESS")
+});
+export type ActivityResultSuccess = t.TypeOf<typeof ActivityResultSuccess>;
+
+export const ActivityResultFailure = t.interface({
+  kind: t.literal("FAILURE"),
+  reason: t.string
+});
+
+export type ActivityResultFailure = t.TypeOf<typeof ActivityResultFailure>;
+
+export const ActivityResult = t.taggedUnion("kind", [
+  ActivityResultSuccess,
+  ActivityResultFailure
+]);
+
+export type ActivityResult = t.TypeOf<typeof ActivityResult>;
+
+export const failure = (context: Context, logPrefix: string) => (
+  err: Error,
+  description: string = ""
+) => {
+  const logMessage =
+    description === ""
+      ? `${logPrefix}|FAILURE=${err.message}`
+      : `${logPrefix}|${description}|FAILURE=${err.message}`;
+  context.log.info(logMessage);
+  return ActivityResultFailure.encode({
+    kind: "FAILURE",
+    reason: err.message
+  });
+};
+
+export const failActivity = (context: Context, logPrefix: string) => (
+  errorMessage: string,
+  errorDetails?: string
+) => {
+  const details = errorDetails ? `|ERROR_DETAILS=${errorDetails}` : ``;
+  context.log.error(`${logPrefix}|${errorMessage}${details}`);
+  return ActivityResultFailure.encode({
+    kind: "FAILURE",
+    reason: errorMessage
+  });
+};
+
+// trigger a rety in case the notification fail
+export const retryActivity = (context: Context, msg: string) => {
+  context.log.error(msg);
+  throw toError(msg);
+};
+
+export const success = () =>
+  ActivityResultSuccess.encode({
+    kind: "SUCCESS"
+  });


### PR DESCRIPTION
#### List of Changes
- Added  `HandleNHNotificationCall` test
- Splitted `HandleNHNotificationCall` body based on message kind, in order to substitute each `case` separately
- Added `activity.ts` file for grouping Activity related functions 


#### TODO
- Create 3 more PRs to split the Orchestrator into 3 different Orchestrators

#### Motivation and Context
In order to prepare the Notification Hub migration, we are preparing the code to be able to handle an incremental rollout.
This is the preliminary step, that should not impact current management.
This is the first of a series of PR, useful for making the code review simpler and more effective

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.