### PR TITLE
moved Delete management into new Orchestrator

### DIFF
--- a/HandleNHDeleteInstallationCallActivityLegacy/__tests__/handler.test.ts
+++ b/HandleNHDeleteInstallationCallActivityLegacy/__tests__/handler.test.ts
@@ -1,0 +1,32 @@
+// tslint:disable:no-any
+
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { getCallNHDeleteInstallationActivityHandler } from "../handler";
+import { ActivityInput as NHServiceActivityInput } from "../handler";
+
+import * as azure from "azure-sb";
+import { DeleteInstallationMessage } from "../../generated/notifications/DeleteInstallationMessage";
+
+const deleteInstallationSpy = jest
+  .spyOn(azure.NotificationHubService.prototype, "deleteInstallation")
+  .mockImplementation((_, cb) => cb(new Error("deleteInstallation error")));
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+
+const aDeleteInStalltionMessage: DeleteInstallationMessage = {
+  installationId: aFiscalCodeHash,
+  kind: "DeleteInstallation" as any
+};
+
+describe("HandleNHDeleteInstallationCallActivityLegacy", () => {
+  it("should NOT trigger a retry if deleteInstallation fails", async () => {
+    const handler = getCallNHDeleteInstallationActivityHandler();
+    const input = NHServiceActivityInput.encode({
+      message: aDeleteInStalltionMessage
+    });
+    const res = await handler(contextMock as any, input);
+    expect(deleteInstallationSpy).toHaveBeenCalledTimes(1);
+    expect(res.kind).toEqual("FAILURE");
+  });
+});

--- a/HandleNHDeleteInstallationCallActivityLegacy/function.json
+++ b/HandleNHDeleteInstallationCallActivityLegacy/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/HandleNHDeleteInstallationCallActivityLegacy/index.js"
+}

--- a/HandleNHDeleteInstallationCallActivityLegacy/handler.ts
+++ b/HandleNHDeleteInstallationCallActivityLegacy/handler.ts
@@ -1,0 +1,62 @@
+import * as t from "io-ts";
+
+import { Context } from "@azure/functions";
+import { toString } from "fp-ts/lib/function";
+
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+import { fromEither } from "fp-ts/lib/TaskEither";
+import { DeleteInstallationMessage } from "../generated/notifications/DeleteInstallationMessage";
+import { deleteInstallation } from "../utils/notification";
+
+import {
+  ActivityResult,
+  ActivityResultFailure,
+  ActivityResultSuccess,
+  success
+} from "../utils/activity";
+
+// Activity input
+export const ActivityInput = t.interface({
+  message: DeleteInstallationMessage
+});
+
+export type ActivityInput = t.TypeOf<typeof ActivityInput>;
+
+const failActivity = (context: Context, logPrefix: string) => (
+  errorMessage: string,
+  errorDetails?: string
+) => {
+  const details = errorDetails ? `|ERROR_DETAILS=${errorDetails}` : ``;
+  context.log.error(`${logPrefix}|${errorMessage}${details}`);
+  return ActivityResultFailure.encode({
+    kind: "FAILURE",
+    reason: errorMessage
+  });
+};
+
+/**
+ * For each Notification Hub Message of type "Delete" calls related Notification Hub service
+ */
+export const getCallNHDeleteInstallationActivityHandler = (
+  logPrefix = "NHDeleteCallServiceActivity"
+) => async (context: Context, input: unknown) => {
+  const failure = failActivity(context, logPrefix);
+  return fromEither(ActivityInput.decode(input))
+    .mapLeft(errs =>
+      failure("Error decoding activity input", readableReport(errs))
+    )
+    .chain<ActivityResultSuccess>(({ message }) => {
+      context.log.info(
+        `${logPrefix}|${message.kind}|INSTALLATION_ID=${message.installationId}`
+      );
+
+      return deleteInstallation(message.installationId).mapLeft(e => {
+        // do not trigger a retry as delete may fail in case of 404
+        context.log.error(`${logPrefix}|ERROR=${toString(e)}`);
+        return failure(e.message);
+      });
+    })
+    .fold<ActivityResult>(err => err, _ => success())
+    .run();
+};

--- a/HandleNHDeleteInstallationCallActivityLegacy/index.ts
+++ b/HandleNHDeleteInstallationCallActivityLegacy/index.ts
@@ -1,0 +1,7 @@
+﻿import { getCallNHDeleteInstallationActivityHandler } from "./handler";
+
+const activityFunctionHandler = getCallNHDeleteInstallationActivityHandler();
+
+export const activityName = "HandleNHDeleteInstallationCallActivityLegacy";
+
+export default activityFunctionHandler;

--- a/HandleNHDeleteInstallationCallOrchestratorLegacy/__tests__/handler.test.ts
+++ b/HandleNHDeleteInstallationCallOrchestratorLegacy/__tests__/handler.test.ts
@@ -1,0 +1,86 @@
+// tslint:disable:no-any
+
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { KindEnum as DeleteKind } from "../../generated/notifications/DeleteInstallationMessage";
+
+import { DeleteInstallationMessage } from "../../generated/notifications/DeleteInstallationMessage";
+import { ActivityInput as NHCallServiceActivityInput } from "../../HandleNHDeleteInstallationCallActivityLegacy/handler";
+import { ActivityResult } from "../../utils/activity";
+import {
+  handler,
+  NhDeleteInstallationOrchestratorCallLegacyInput
+} from "../handler";
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+
+const aDeleteNotificationHubMessage: DeleteInstallationMessage = {
+  installationId: aFiscalCodeHash,
+  kind: DeleteKind.DeleteInstallation
+};
+
+const retryOptions = {
+  backoffCoefficient: 1.5
+};
+
+describe("HandleNHDeleteInstallationCallOrchestratorLegacy", () => {
+  it("should start the activities with the right inputs", async () => {
+    const nhCallOrchestratorInput = NhDeleteInstallationOrchestratorCallLegacyInput.encode(
+      {
+        message: aDeleteNotificationHubMessage
+      }
+    );
+
+    const callNHServiceActivityResult = ActivityResult.encode({
+      kind: "SUCCESS"
+    });
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(callNHServiceActivityResult),
+        getInput: jest.fn(() => nhCallOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = handler(contextMockWithDf as any);
+
+    orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "HandleNHDeleteInstallationCallActivityLegacy",
+      retryOptions,
+      NHCallServiceActivityInput.encode({
+        message: aDeleteNotificationHubMessage
+      })
+    );
+  });
+
+  it("should not start activity with wrong inputs", async () => {
+    const nhCallOrchestratorInput = {
+      message: "aMessage"
+    };
+
+    const callNHServiceActivityResult = ActivityResult.encode({
+      kind: "SUCCESS"
+    });
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(callNHServiceActivityResult),
+        getInput: jest.fn(() => nhCallOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = handler(contextMockWithDf as any);
+
+    orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toBeCalled();
+  });
+});

--- a/HandleNHDeleteInstallationCallOrchestratorLegacy/function.json
+++ b/HandleNHDeleteInstallationCallOrchestratorLegacy/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/HandleNHDeleteInstallationCallOrchestratorLegacy/index.js"
+}

--- a/HandleNHDeleteInstallationCallOrchestratorLegacy/handler.ts
+++ b/HandleNHDeleteInstallationCallOrchestratorLegacy/handler.ts
@@ -1,0 +1,68 @@
+import * as t from "io-ts";
+
+import { isLeft } from "fp-ts/lib/Either";
+
+import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes";
+
+import * as df from "durable-functions";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+import { DeleteInstallationMessage } from "../generated/notifications/DeleteInstallationMessage";
+
+import { activityName as DeleteInstallationActivityName } from "../HandleNHDeleteInstallationCallActivityLegacy/index";
+
+/**
+ * Carries information about Notification Hub Message payload
+ */
+export const NhDeleteInstallationOrchestratorCallLegacyInput = t.interface({
+  message: DeleteInstallationMessage
+});
+
+export type NhDeleteInstallationOrchestratorCallLegacyInput = t.TypeOf<
+  typeof NhDeleteInstallationOrchestratorCallLegacyInput
+>;
+
+const logError = (
+  context: IOrchestrationFunctionContext,
+  logPrefix: string,
+  errorOrNHCallOrchestratorInput
+) => {
+  context.log.error(`${logPrefix}|Error decoding input`);
+  context.log.verbose(
+    `${logPrefix}|Error decoding input|ERROR=${readableReport(
+      errorOrNHCallOrchestratorInput.value
+    )}`
+  );
+};
+
+export const handler = function*(
+  context: IOrchestrationFunctionContext
+): Generator<unknown> {
+  const logPrefix = `NhDeleteInstallationOrchestratorCallLegacyInput`;
+
+  const retryOptions = {
+    ...new df.RetryOptions(5000, 10),
+    backoffCoefficient: 1.5
+  };
+
+  // Get and decode orchestrator input
+  const input = context.df.getInput();
+  const errorOrNHCallOrchestratorInput = NhDeleteInstallationOrchestratorCallLegacyInput.decode(
+    input
+  );
+
+  if (isLeft(errorOrNHCallOrchestratorInput)) {
+    logError(context, logPrefix, errorOrNHCallOrchestratorInput);
+    return false;
+  }
+
+  const nhCallOrchestratorInput = errorOrNHCallOrchestratorInput.value;
+
+  yield context.df.callActivityWithRetry(
+    DeleteInstallationActivityName,
+    retryOptions,
+    nhCallOrchestratorInput
+  );
+
+  return true;
+};

--- a/HandleNHDeleteInstallationCallOrchestratorLegacy/index.ts
+++ b/HandleNHDeleteInstallationCallOrchestratorLegacy/index.ts
@@ -1,0 +1,10 @@
+﻿import * as df from "durable-functions";
+
+import { handler } from "./handler";
+
+const orchestrator = df.orchestrator(handler);
+
+export const orchestratorName =
+  "HandleNHDeleteInstallationCallOrchestratorLegacy";
+
+export default orchestrator;

--- a/HandleNHNotificationCall/__tests__/index.test.ts
+++ b/HandleNHNotificationCall/__tests__/index.test.ts
@@ -51,7 +51,7 @@ describe("HandleNHNotificationCall", () => {
     await HandleNHNotificationCall(context as any, aDeleteInStalltionMessage);
 
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "HandleNHNotificationCallOrchestrator",
+      "HandleNHDeleteInstallationCallOrchestratorLegacy",
       undefined,
       {
         message: aDeleteInStalltionMessage

--- a/HandleNHNotificationCall/index.ts
+++ b/HandleNHNotificationCall/index.ts
@@ -4,6 +4,8 @@ import { toString } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { initTelemetryClient } from "../utils/appinsights";
 
+import { orchestratorName as DeleteInstallationOrchestratorName } from "../HandleNHDeleteInstallationCallOrchestratorLegacy/index";
+
 import { CreateOrUpdateInstallationMessage } from "../generated/notifications/CreateOrUpdateInstallationMessage";
 import { DeleteInstallationMessage } from "../generated/notifications/DeleteInstallationMessage";
 import { NotifyMessage } from "../generated/notifications/NotifyMessage";
@@ -37,7 +39,7 @@ export async function index(
   switch (notificationHubMessage.kind) {
     case DeleteKind.DeleteInstallation:
       const client = df.getClient(context);
-      await client.startNew("HandleNHNotificationCallOrchestrator", undefined, {
+      await client.startNew(DeleteInstallationOrchestratorName, undefined, {
         message: notificationHubMessage
       });
       break;


### PR DESCRIPTION
#### List of Changes
- Added  `HandleNHDeleteInstallationCallOrchestratorLegacy`
- Added `HandleNHDeleteInstallationCallActivityLegacy`
- Change `HandleNHNotificationCall` accordingly


#### TODO
- Move NH Namespace and NH name outside the service call

#### Motivation and Context
In order to prepare the Notification Hub migration, we are preparing the code to be able to handle an incremental rollout.
This is the preliminary step, that should not impact current management.
This is the second of a series of PR, useful for making the code review simpler and more effective

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.