### PR TITLE
moved CreateOrUpdate Installation management into new Orchestrator

### DIFF
--- a/HandleNHCreateOrUpdateInstallationCallActivityLegacy/__tests__/handler.test.ts
+++ b/HandleNHCreateOrUpdateInstallationCallActivityLegacy/__tests__/handler.test.ts
@@ -1,0 +1,43 @@
+// tslint:disable:no-any
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { getCallNHCreateOrUpdateInstallationActivityHandler } from "../handler";
+import { ActivityInput as NHServiceActivityInput } from "../handler";
+
+import * as azure from "azure-sb";
+import { PlatformEnum } from "../../generated/backend/Platform";
+import { CreateOrUpdateInstallationMessage } from "../../generated/notifications/CreateOrUpdateInstallationMessage";
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+const aPushChannel =
+  "fLKP3EATnBI:APA91bEy4go681jeSEpLkNqhtIrdPnEKu6Dfi-STtUiEnQn8RwMfBiPGYaqdWrmzJyXIh5Yms4017MYRS9O1LGPZwA4sOLCNIoKl4Fwg7cSeOkliAAtlQ0rVg71Kr5QmQiLlDJyxcq3p";
+
+const aCreateOrUpdateInstallationMessage: CreateOrUpdateInstallationMessage = {
+  installationId: aFiscalCodeHash,
+  kind: "CreateOrUpdateInstallation" as any,
+  platform: PlatformEnum.apns,
+  pushChannel: aPushChannel,
+  tags: [aFiscalCodeHash]
+};
+
+const createOrUpdateInstallationSpy = jest
+  .spyOn(azure.NotificationHubService.prototype, "createOrUpdateInstallation")
+  .mockImplementation((_, cb) =>
+    cb(new Error("createOrUpdateInstallation error"))
+  );
+
+describe("HandleNHCreateOrUpdateInstallationCallActivity", () => {
+  it("should trigger a retry if CreateOrUpdateInstallation fails", async () => {
+    const handler = getCallNHCreateOrUpdateInstallationActivityHandler();
+    const input = NHServiceActivityInput.encode({
+      message: aCreateOrUpdateInstallationMessage
+    });
+    expect.assertions(2);
+    try {
+      await handler(contextMock as any, input);
+    } catch (e) {
+      expect(createOrUpdateInstallationSpy).toHaveBeenCalledTimes(1);
+      expect(e).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/HandleNHCreateOrUpdateInstallationCallActivityLegacy/function.json
+++ b/HandleNHCreateOrUpdateInstallationCallActivityLegacy/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/HandleNHCreateOrUpdateInstallationCallActivity/index.js"
+}

--- a/HandleNHCreateOrUpdateInstallationCallActivityLegacy/handler.ts
+++ b/HandleNHCreateOrUpdateInstallationCallActivityLegacy/handler.ts
@@ -1,0 +1,55 @@
+import * as t from "io-ts";
+
+import { Context } from "@azure/functions";
+import { toString } from "fp-ts/lib/function";
+
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+import { fromEither } from "fp-ts/lib/TaskEither";
+import { createOrUpdateInstallation } from "../utils/notification";
+
+import { CreateOrUpdateInstallationMessage } from "../generated/notifications/CreateOrUpdateInstallationMessage";
+
+import {
+  ActivityResult,
+  ActivityResultSuccess,
+  failActivity,
+  retryActivity,
+  success
+} from "../utils/activity";
+
+// Activity input
+export const ActivityInput = t.interface({
+  message: CreateOrUpdateInstallationMessage
+});
+
+export type ActivityInput = t.TypeOf<typeof ActivityInput>;
+
+/**
+ * For each Notification Hub Message of type "Delete" calls related Notification Hub service
+ */
+export const getCallNHCreateOrUpdateInstallationActivityHandler = (
+  logPrefix = "NHCreateOrUpdateCallServiceActivityLegacy"
+) => async (context: Context, input: unknown) => {
+  const failure = failActivity(context, logPrefix);
+  return fromEither(ActivityInput.decode(input))
+    .mapLeft(errs =>
+      failure("Error decoding activity input", readableReport(errs))
+    )
+    .chain<ActivityResultSuccess>(({ message }) => {
+      context.log.info(
+        `${logPrefix}|${message.kind}|INSTALLATION_ID=${message.installationId}`
+      );
+
+      return createOrUpdateInstallation(
+        message.installationId,
+        message.platform,
+        message.pushChannel,
+        message.tags
+      ).mapLeft(e =>
+        retryActivity(context, `${logPrefix}|ERROR=${toString(e)}`)
+      );
+    })
+    .fold<ActivityResult>(err => err, _ => success())
+    .run();
+};

--- a/HandleNHCreateOrUpdateInstallationCallActivityLegacy/index.ts
+++ b/HandleNHCreateOrUpdateInstallationCallActivityLegacy/index.ts
@@ -1,0 +1,8 @@
+﻿import { getCallNHCreateOrUpdateInstallationActivityHandler } from "./handler";
+
+const activityFunctionHandler = getCallNHCreateOrUpdateInstallationActivityHandler();
+
+export const activityName =
+  "HandleNHCreateOrUpdateInstallationCallActivityLegacy";
+
+export default activityFunctionHandler;

--- a/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/__tests__/handler.test.ts
+++ b/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/__tests__/handler.test.ts
@@ -1,0 +1,82 @@
+// tslint:disable:no-any
+
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { PlatformEnum } from "../../generated/backend/Platform";
+import {
+  CreateOrUpdateInstallationMessage,
+  KindEnum as CreateOrUpdateKind
+} from "../../generated/notifications/CreateOrUpdateInstallationMessage";
+
+import { ActivityInput as NHCallServiceActivityInput } from "../../HandleNHCreateOrUpdateInstallationCallActivityLegacy/handler";
+import { success } from "../../utils/activity";
+import {
+  handler,
+  NhCreateOrUpdateInstallationOrchestratorCallLegacyInput
+} from "../handler";
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+const aPushChannel =
+  "fLKP3EATnBI:APA91bEy4go681jeSEpLkNqhtIrdPnEKu6Dfi-STtUiEnQn8RwMfBiPGYaqdWrmzJyXIh5Yms4017MYRS9O1LGPZwA4sOLCNIoKl4Fwg7cSeOkliAAtlQ0rVg71Kr5QmQiLlDJyxcq3p";
+
+const aCreateOrUpdateInstallationMessage: CreateOrUpdateInstallationMessage = {
+  installationId: aFiscalCodeHash,
+  kind: CreateOrUpdateKind.CreateOrUpdateInstallation,
+  platform: PlatformEnum.apns,
+  pushChannel: aPushChannel,
+  tags: [aFiscalCodeHash]
+};
+
+const retryOptions = {
+  backoffCoefficient: 1.5
+};
+
+describe("HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy", () => {
+  it("should start the activities with the right inputs", async () => {
+    const nhCallOrchestratorInput = NhCreateOrUpdateInstallationOrchestratorCallLegacyInput.encode(
+      {
+        message: aCreateOrUpdateInstallationMessage
+      }
+    );
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest.fn().mockReturnValueOnce(success()),
+        getInput: jest.fn(() => nhCallOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = handler(contextMockWithDf as any);
+
+    orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "HandleNHCreateOrUpdateInstallationCallActivityLegacy",
+      retryOptions,
+      NHCallServiceActivityInput.encode({
+        message: aCreateOrUpdateInstallationMessage
+      })
+    );
+  });
+
+  it("should not start activity with wrong inputs", async () => {
+    const nhCallOrchestratorInput = {
+      message: "aMessage"
+    };
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest.fn().mockReturnValueOnce(success()),
+        getInput: jest.fn(() => nhCallOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = handler(contextMockWithDf as any);
+
+    orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toBeCalled();
+  });
+});

--- a/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/function.json
+++ b/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/index.js"
+}

--- a/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/handler.ts
+++ b/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/handler.ts
@@ -1,0 +1,70 @@
+import * as t from "io-ts";
+
+import { isLeft } from "fp-ts/lib/Either";
+
+import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes";
+
+import * as df from "durable-functions";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+import { CreateOrUpdateInstallationMessage } from "../generated/notifications/CreateOrUpdateInstallationMessage";
+import { activityName as CreateOrUpdateActivityName } from "../HandleNHCreateOrUpdateInstallationCallActivityLegacy/index";
+
+/**
+ * Carries information about Notification Hub Message payload
+ */
+export const NhCreateOrUpdateInstallationOrchestratorCallLegacyInput = t.interface(
+  {
+    message: CreateOrUpdateInstallationMessage
+  }
+);
+
+export type NhCreateOrUpdateInstallationOrchestratorCallLegacyInput = t.TypeOf<
+  typeof NhCreateOrUpdateInstallationOrchestratorCallLegacyInput
+>;
+
+const logError = (
+  context: IOrchestrationFunctionContext,
+  logPrefix: string,
+  errorOrNHCallOrchestratorInput
+) => {
+  context.log.error(`${logPrefix}|Error decoding input`);
+  context.log.verbose(
+    `${logPrefix}|Error decoding input|ERROR=${readableReport(
+      errorOrNHCallOrchestratorInput.value
+    )}`
+  );
+};
+
+export const handler = function*(
+  context: IOrchestrationFunctionContext
+): Generator<unknown> {
+  const logPrefix = `NhCreateOrUpdateInstallationOrchestratorLegacyCallInput`;
+
+  const retryOptions = {
+    ...new df.RetryOptions(5000, 10),
+    backoffCoefficient: 1.5
+  };
+
+  // Get and decode orchestrator input
+  const input = context.df.getInput();
+  const errorOrNHCreateOrUpdateCallOrchestratorInput = NhCreateOrUpdateInstallationOrchestratorCallLegacyInput.decode(
+    input
+  );
+
+  if (isLeft(errorOrNHCreateOrUpdateCallOrchestratorInput)) {
+    logError(context, logPrefix, errorOrNHCreateOrUpdateCallOrchestratorInput);
+    return false;
+  }
+
+  const nhCallOrchestratorInput =
+    errorOrNHCreateOrUpdateCallOrchestratorInput.value;
+
+  yield context.df.callActivityWithRetry(
+    CreateOrUpdateActivityName,
+    retryOptions,
+    nhCallOrchestratorInput
+  );
+
+  return true;
+};

--- a/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/index.ts
+++ b/HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/index.ts
@@ -1,0 +1,10 @@
+﻿import * as df from "durable-functions";
+
+import { handler } from "./handler";
+
+const orchestrator = df.orchestrator(handler);
+
+export const orchestratorName =
+  "HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy";
+
+export default orchestrator;

--- a/HandleNHNotificationCall/__tests__/index.test.ts
+++ b/HandleNHNotificationCall/__tests__/index.test.ts
@@ -66,7 +66,7 @@ describe("HandleNHNotificationCall", () => {
     );
 
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "HandleNHNotificationCallOrchestrator",
+      "HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy",
       undefined,
       {
         message: aCreateOrUpdateInstallationMessage

--- a/HandleNHNotificationCall/index.ts
+++ b/HandleNHNotificationCall/index.ts
@@ -4,6 +4,8 @@ import { toString } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { initTelemetryClient } from "../utils/appinsights";
 
+import { orchestratorName as CreateOrUpdateOrchestratorName } from "../HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy/index";
+
 import { CreateOrUpdateInstallationMessage } from "../generated/notifications/CreateOrUpdateInstallationMessage";
 import { DeleteInstallationMessage } from "../generated/notifications/DeleteInstallationMessage";
 import { NotifyMessage } from "../generated/notifications/NotifyMessage";
@@ -19,7 +21,6 @@ export const NotificationMessage = t.union([
 ]);
 
 export type NotificationHubMessage = t.TypeOf<typeof NotificationMessage>;
-
 const assertNever = (x: never): never => {
   throw new Error(`Unexpected object: ${toString(x)}`);
 };
@@ -43,13 +44,9 @@ export async function index(
       break;
     case CreateOrUpdateKind.CreateOrUpdateInstallation:
       const client2 = df.getClient(context);
-      await client2.startNew(
-        "HandleNHNotificationCallOrchestrator",
-        undefined,
-        {
-          message: notificationHubMessage
-        }
-      );
+      await client2.startNew(CreateOrUpdateOrchestratorName, undefined, {
+        message: notificationHubMessage
+      });
       break;
     case NotifyKind.Notify:
       const client3 = df.getClient(context);


### PR DESCRIPTION
#### List of Changes
- Added  `HandleNHCreateOrUpdateInstallationCallOrchestratorLegacy`
- Added `HandleNHCreateOrUpdateInstallationCallActivityLegacy`
- Change `HandleNHNotificationCall` accordingly


#### TODO
- Move NH Namespace and NH name outside the service call

#### Motivation and Context
In order to prepare the Notification Hub migration, we are preparing the code to be able to handle an incremental rollout.
This is the preliminary step, that should not impact current management.
This is the third of a series of PR, useful for making the code review simpler and more effective

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.