### PR TITLE
moved Notify Message  management into new Orchestrator

### DIFF
--- a/HandleNHNotificationCall/__tests__/index.test.ts
+++ b/HandleNHNotificationCall/__tests__/index.test.ts
@@ -78,7 +78,7 @@ describe("HandleNHNotificationCall", () => {
     await HandleNHNotificationCall(context as any, aNotifyMessage);
 
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "HandleNHNotificationCallOrchestrator",
+      "HandleNHNotifyMessageCallOrchestratorLegacy",
       undefined,
       {
         message: aNotifyMessage

--- a/HandleNHNotificationCall/index.ts
+++ b/HandleNHNotificationCall/index.ts
@@ -4,6 +4,8 @@ import { toString } from "fp-ts/lib/function";
 import * as t from "io-ts";
 import { initTelemetryClient } from "../utils/appinsights";
 
+import { orchestratorName as NotifyMessageOrchestratorName } from "../HandleNHNotifyMessageCallOrchestratorLegacy/index";
+
 import { CreateOrUpdateInstallationMessage } from "../generated/notifications/CreateOrUpdateInstallationMessage";
 import { DeleteInstallationMessage } from "../generated/notifications/DeleteInstallationMessage";
 import { NotifyMessage } from "../generated/notifications/NotifyMessage";
@@ -53,13 +55,9 @@ export async function index(
       break;
     case NotifyKind.Notify:
       const client3 = df.getClient(context);
-      await client3.startNew(
-        "HandleNHNotificationCallOrchestrator",
-        undefined,
-        {
-          message: notificationHubMessage
-        }
-      );
+      await client3.startNew(NotifyMessageOrchestratorName, undefined, {
+        message: notificationHubMessage
+      });
       break;
     default:
       assertNever(notificationHubMessage);

--- a/HandleNHNotifyMessageCallActivityLegacy/__tests__/handler.test.ts
+++ b/HandleNHNotifyMessageCallActivityLegacy/__tests__/handler.test.ts
@@ -1,0 +1,43 @@
+// tslint:disable:no-any
+
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { getCallNHNotifyMessageActivityHandler } from "../handler";
+import { ActivityInput as NHServiceActivityInput } from "../handler";
+
+import * as azure from "azure-sb";
+import { NotifyMessage } from "../../generated/notifications/NotifyMessage";
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+
+const aNotifyMessage: NotifyMessage = {
+  installationId: aFiscalCodeHash,
+  kind: "Notify" as any,
+  payload: {
+    message: "message",
+    message_id: "id",
+    title: "title"
+  }
+};
+
+const notifySpy = jest
+  .spyOn(azure.NotificationHubService.prototype, "send")
+  .mockImplementation((_, __, ___, cb) =>
+    cb(new Error("notify error"), {} as any)
+  );
+
+describe("HandleNHNotifyMessageCallActivityLegacy", () => {
+  it("should trigger a retry if notify fails", async () => {
+    const handler = getCallNHNotifyMessageActivityHandler();
+    const input = NHServiceActivityInput.encode({
+      message: aNotifyMessage
+    });
+    expect.assertions(2);
+    try {
+      await handler(contextMock as any, input);
+    } catch (e) {
+      expect(notifySpy).toHaveBeenCalledTimes(1);
+      expect(e).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/HandleNHNotifyMessageCallActivityLegacy/function.json
+++ b/HandleNHNotifyMessageCallActivityLegacy/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/HandleNHNotifyMessageCallActivityLegacy/index.js"
+}

--- a/HandleNHNotifyMessageCallActivityLegacy/handler.ts
+++ b/HandleNHNotifyMessageCallActivityLegacy/handler.ts
@@ -1,0 +1,65 @@
+import { identity, toString } from "fp-ts/lib/function";
+import { fromEither, taskEither } from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+
+import { Context } from "@azure/functions";
+
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+import {
+  ActivityResult,
+  ActivityResultSuccess,
+  failActivity,
+  retryActivity,
+  success
+} from "../utils/activity";
+import { initTelemetryClient } from "../utils/appinsights";
+import { notify } from "../utils/notification";
+
+import { NotifyMessage } from "../generated/notifications/NotifyMessage";
+
+// Activity input
+export const ActivityInput = t.interface({
+  message: NotifyMessage
+});
+
+export type ActivityInput = t.TypeOf<typeof ActivityInput>;
+
+const telemetryClient = initTelemetryClient();
+
+/**
+ * For each Notification Hub Message of type "Delete" calls related Notification Hub service
+ */
+export const getCallNHNotifyMessageActivityHandler = (
+  logPrefix = "NHNotifyCallServiceActivityLegacy"
+) => async (context: Context, input: unknown) => {
+  const failure = failActivity(context, logPrefix);
+  return fromEither(ActivityInput.decode(input))
+    .mapLeft(errs =>
+      failure("Error decoding activity input", readableReport(errs))
+    )
+    .chain<ActivityResultSuccess>(({ message }) => {
+      context.log.info(
+        `${logPrefix}|${message.kind}|INSTALLATION_ID=${message.installationId}`
+      );
+
+      return notify(message.installationId, message.payload)
+        .mapLeft(e =>
+          retryActivity(context, `${logPrefix}|ERROR=${toString(e)}`)
+        )
+        .chainFirst(
+          taskEither.of(
+            telemetryClient.trackEvent({
+              name: "api.messages.notification.push.sent",
+              properties: {
+                isSuccess: "true",
+                messageId: message.payload.message_id
+              },
+              tagOverrides: { samplingEnabled: "false" }
+            })
+          )
+        );
+    })
+    .fold<ActivityResult>(identity, _ => success())
+    .run();
+};

--- a/HandleNHNotifyMessageCallActivityLegacy/index.ts
+++ b/HandleNHNotifyMessageCallActivityLegacy/index.ts
@@ -1,0 +1,7 @@
+﻿import { getCallNHNotifyMessageActivityHandler } from "./handler";
+
+const activityFunctionHandler = getCallNHNotifyMessageActivityHandler();
+
+export const activityName = "HandleNHNotifyMessageCallActivityLegacy";
+
+export default activityFunctionHandler;

--- a/HandleNHNotifyMessageCallOrchestratorLegacy/__tests__/handler.test.ts
+++ b/HandleNHNotifyMessageCallOrchestratorLegacy/__tests__/handler.test.ts
@@ -1,0 +1,81 @@
+// tslint:disable:no-any
+
+import { NonEmptyString } from "italia-ts-commons/lib/strings";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import { success } from "../../utils/activity";
+
+import { KindEnum as NotifyMessageKind } from "../../generated/notifications/NotifyMessage";
+import { NotifyMessage } from "../../generated/notifications/NotifyMessage";
+
+import { ActivityInput as NHCallServiceActivityInput } from "../../HandleNHNotifyMessageCallActivityLegacy/handler";
+
+import {
+  handler,
+  NhNotifyMessageOrchestratorCallLegacyInput
+} from "../handler";
+
+const aFiscalCodeHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" as NonEmptyString;
+
+const aNotifyMessage: NotifyMessage = {
+  installationId: aFiscalCodeHash,
+  kind: NotifyMessageKind.Notify,
+  payload: {
+    message: "message",
+    message_id: "id",
+    title: "title"
+  }
+};
+
+const retryOptions = {
+  backoffCoefficient: 1.5
+};
+
+describe("HandleNHNotifyMessageCallOrchestratorLegacy", () => {
+  it("should start the activities with the right inputs", async () => {
+    const nhCallOrchestratorInput = NhNotifyMessageOrchestratorCallLegacyInput.encode(
+      {
+        message: aNotifyMessage
+      }
+    );
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest.fn().mockReturnValueOnce(success()),
+        getInput: jest.fn(() => nhCallOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = handler(contextMockWithDf as any);
+
+    orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "HandleNHNotifyMessageCallActivityLegacy",
+      retryOptions,
+      NHCallServiceActivityInput.encode({
+        message: aNotifyMessage
+      })
+    );
+  });
+
+  it("should not start activity with wrong inputs", async () => {
+    const nhCallOrchestratorInput = {
+      message: "aMessage"
+    };
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest.fn().mockReturnValueOnce(success()),
+        getInput: jest.fn(() => nhCallOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = handler(contextMockWithDf as any);
+
+    orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toBeCalled();
+  });
+});

--- a/HandleNHNotifyMessageCallOrchestratorLegacy/function.json
+++ b/HandleNHNotifyMessageCallOrchestratorLegacy/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/HandleNHNotifyMessageCallOrchestratorLegacy/index.js"
+}

--- a/HandleNHNotifyMessageCallOrchestratorLegacy/handler.ts
+++ b/HandleNHNotifyMessageCallOrchestratorLegacy/handler.ts
@@ -1,0 +1,68 @@
+import * as t from "io-ts";
+
+import { isLeft } from "fp-ts/lib/Either";
+
+import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes";
+
+import * as df from "durable-functions";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+import { NotifyMessage } from "../generated/notifications/NotifyMessage";
+
+import { activityName as NotifyMessageActivityName } from "../HandleNHNotifyMessageCallActivityLegacy/index";
+
+/**
+ * Carries information about Notification Hub Message payload
+ */
+export const NhNotifyMessageOrchestratorCallLegacyInput = t.interface({
+  message: NotifyMessage
+});
+
+export type NhNotifyMessageOrchestratorCallLegacyInput = t.TypeOf<
+  typeof NhNotifyMessageOrchestratorCallLegacyInput
+>;
+
+const logError = (
+  context: IOrchestrationFunctionContext,
+  logPrefix: string,
+  errorOrNHCallOrchestratorInput
+) => {
+  context.log.error(`${logPrefix}|Error decoding input`);
+  context.log.verbose(
+    `${logPrefix}|Error decoding input|ERROR=${readableReport(
+      errorOrNHCallOrchestratorInput.value
+    )}`
+  );
+};
+
+export const handler = function*(
+  context: IOrchestrationFunctionContext
+): Generator<unknown> {
+  const logPrefix = `NhNotifyMessageOrchestratorCallLegacyInput`;
+
+  const retryOptions = {
+    ...new df.RetryOptions(5000, 10),
+    backoffCoefficient: 1.5
+  };
+
+  // Get and decode orchestrator input
+  const input = context.df.getInput();
+  const errorOrNHCallOrchestratorInput = NhNotifyMessageOrchestratorCallLegacyInput.decode(
+    input
+  );
+
+  if (isLeft(errorOrNHCallOrchestratorInput)) {
+    logError(context, logPrefix, errorOrNHCallOrchestratorInput);
+    return false;
+  }
+
+  const nhCallOrchestratorInput = errorOrNHCallOrchestratorInput.value;
+
+  yield context.df.callActivityWithRetry(
+    NotifyMessageActivityName,
+    retryOptions,
+    nhCallOrchestratorInput
+  );
+
+  return true;
+};

--- a/HandleNHNotifyMessageCallOrchestratorLegacy/index.ts
+++ b/HandleNHNotifyMessageCallOrchestratorLegacy/index.ts
@@ -1,0 +1,9 @@
+﻿import * as df from "durable-functions";
+
+import { handler } from "./handler";
+
+const orchestrator = df.orchestrator(handler);
+
+export const orchestratorName = "HandleNHNotifyMessageCallOrchestratorLegacy";
+
+export default orchestrator;


### PR DESCRIPTION
#### List of Changes
- Added  `HandleNHNotifyMessageCallOrchestratorLegacy`
- Added `HandleNHNotifyMessageCallActivityLegacy`
- Change `HandleNHNotificationCall` accordingly


#### TODO
- Move NH Namespace and NH name outside the service call

#### Motivation and Context
In order to prepare the Notification Hub migration, we are preparing the code to be able to handle an incremental rollout.
This is the preliminary step, that should not impact current management.
This is the fourth of a series of PR, useful for making the code review simpler and more effective

#### How Has This Been Tested?
It has been tested by performing unit tests .

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.