### PR TITLE
[#IPV-52] Enqueue a message when a User Profile is activated

### DIFF
--- a/EnqueueProfileCreationEventActivity/__tests__/handler.test.ts
+++ b/EnqueueProfileCreationEventActivity/__tests__/handler.test.ts
@@ -1,0 +1,67 @@
+import { Context } from "@azure/functions";
+import { QueueServiceClient } from "@azure/storage-queue";
+import { context } from "../../__mocks__/durable-functions";
+import { aFiscalCode } from "../../__mocks__/mocks";
+import { GetEnqueueProfileCreationEventActivityHandler } from "../handler";
+
+const mockSendMessage = jest.fn();
+const mockQueueService = ({
+  getQueueClient: jest
+    .fn()
+    .mockImplementation(() => ({ sendMessage: mockSendMessage }))
+} as unknown) as QueueServiceClient;
+
+const aQueueName = "queue_name";
+
+describe("GetEnqueueProfileCreationEventActivityHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("Should send a message if the activity input is valid", async () => {
+    const handler = GetEnqueueProfileCreationEventActivityHandler(
+      mockQueueService
+    );
+    mockSendMessage.mockImplementation(() => Promise.resolve());
+    // tslint:disable-next-line: no-unused-expression
+    const result = await handler((context as unknown) as Context, {
+      fiscalCode: aFiscalCode,
+      queueName: aQueueName
+    });
+    expect(result).toEqual("SUCCESS");
+    expect(mockSendMessage).toBeCalledWith(aFiscalCode);
+    expect(mockQueueService.getQueueClient).toBeCalledWith(aQueueName);
+  });
+
+  it("Should return permanent error when the input is invalid", async () => {
+    const handler = GetEnqueueProfileCreationEventActivityHandler(
+      mockQueueService
+    );
+    mockSendMessage.mockImplementation(() => Promise.resolve());
+    // tslint:disable-next-line: no-unused-expression
+    const result = await handler((context as unknown) as Context, {
+      fiscalCode: aFiscalCode
+    });
+    expect(result).toEqual("FAILURE");
+    expect(context.log.error).toBeCalled();
+    expect(mockQueueService.getQueueClient).not.toBeCalled();
+  });
+
+  it("Should return transient error if queue service fail", async () => {
+    const handler = GetEnqueueProfileCreationEventActivityHandler(
+      mockQueueService
+    );
+    mockSendMessage.mockImplementationOnce(() =>
+      Promise.reject(new Error("Error"))
+    );
+    // tslint:disable-next-line: no-unused-expression
+    await expect(
+      handler((context as unknown) as Context, {
+        fiscalCode: aFiscalCode,
+        queueName: aQueueName
+      })
+    ).rejects.toEqual(expect.any(Error));
+    expect(mockQueueService.getQueueClient).toBeCalledWith(aQueueName);
+    expect(mockSendMessage).toBeCalledWith(aFiscalCode);
+    expect(context.log.error).toBeCalled();
+  });
+});

--- a/EnqueueProfileCreationEventActivity/__tests__/handler.test.ts
+++ b/EnqueueProfileCreationEventActivity/__tests__/handler.test.ts
@@ -28,7 +28,9 @@ describe("GetEnqueueProfileCreationEventActivityHandler", () => {
       queueName: aQueueName
     });
     expect(result).toEqual("SUCCESS");
-    expect(mockSendMessage).toBeCalledWith(aFiscalCode);
+    expect(mockSendMessage).toBeCalledWith(
+      Buffer.from(aFiscalCode).toString("base64")
+    );
     expect(mockQueueService.getQueueClient).toBeCalledWith(aQueueName);
   });
 
@@ -61,7 +63,9 @@ describe("GetEnqueueProfileCreationEventActivityHandler", () => {
       })
     ).rejects.toEqual(expect.any(Error));
     expect(mockQueueService.getQueueClient).toBeCalledWith(aQueueName);
-    expect(mockSendMessage).toBeCalledWith(aFiscalCode);
+    expect(mockSendMessage).toBeCalledWith(
+      Buffer.from(aFiscalCode).toString("base64")
+    );
     expect(context.log.error).toBeCalled();
   });
 });

--- a/EnqueueProfileCreationEventActivity/__tests__/handler.test.ts
+++ b/EnqueueProfileCreationEventActivity/__tests__/handler.test.ts
@@ -2,7 +2,10 @@ import { Context } from "@azure/functions";
 import { QueueServiceClient } from "@azure/storage-queue";
 import { context } from "../../__mocks__/durable-functions";
 import { aFiscalCode } from "../../__mocks__/mocks";
-import { GetEnqueueProfileCreationEventActivityHandler } from "../handler";
+import {
+  GetEnqueueProfileCreationEventActivityHandler,
+  NewProfileInput
+} from "../handler";
 
 const mockSendMessage = jest.fn();
 const mockQueueService = ({
@@ -12,6 +15,10 @@ const mockQueueService = ({
 } as unknown) as QueueServiceClient;
 
 const aQueueName = "queue_name";
+
+const expectedMessagePayload: NewProfileInput = {
+  fiscal_code: aFiscalCode
+};
 
 describe("GetEnqueueProfileCreationEventActivityHandler", () => {
   beforeEach(() => {
@@ -29,7 +36,7 @@ describe("GetEnqueueProfileCreationEventActivityHandler", () => {
     });
     expect(result).toEqual("SUCCESS");
     expect(mockSendMessage).toBeCalledWith(
-      Buffer.from(aFiscalCode).toString("base64")
+      Buffer.from(JSON.stringify(expectedMessagePayload)).toString("base64")
     );
     expect(mockQueueService.getQueueClient).toBeCalledWith(aQueueName);
   });
@@ -64,7 +71,7 @@ describe("GetEnqueueProfileCreationEventActivityHandler", () => {
     ).rejects.toEqual(expect.any(Error));
     expect(mockQueueService.getQueueClient).toBeCalledWith(aQueueName);
     expect(mockSendMessage).toBeCalledWith(
-      Buffer.from(aFiscalCode).toString("base64")
+      Buffer.from(JSON.stringify(expectedMessagePayload)).toString("base64")
     );
     expect(context.log.error).toBeCalled();
   });

--- a/EnqueueProfileCreationEventActivity/function.json
+++ b/EnqueueProfileCreationEventActivity/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/EnqueueProfileCreationEventActivity/index.js"
+}

--- a/EnqueueProfileCreationEventActivity/handler.ts
+++ b/EnqueueProfileCreationEventActivity/handler.ts
@@ -36,7 +36,9 @@ export const GetEnqueueProfileCreationEventActivityHandler: IEnqueueProfileCreat
       queueService
         .getQueueClient(decodedInputOrError.value.queueName)
         // Default message TTL is 7 days @ref https://docs.microsoft.com/it-it/azure/storage/queues/storage-nodejs-how-to-use-queues?tabs=javascript#queue-service-concepts
-        .sendMessage(decodedInputOrError.value.fiscalCode),
+        .sendMessage(
+          Buffer.from(decodedInputOrError.value.fiscalCode).toString("base64")
+        ),
     err => {
       context.log.error(
         `EnqueueProfileCreationEventActivity|Cannot send a message to the queue ${

--- a/EnqueueProfileCreationEventActivity/handler.ts
+++ b/EnqueueProfileCreationEventActivity/handler.ts
@@ -1,0 +1,53 @@
+import { Context } from "@azure/functions";
+import { QueueServiceClient } from "@azure/storage-queue";
+import { tryCatch } from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
+
+export const EnqueueProfileCreationEventActivityInput = t.interface({
+  fiscalCode: FiscalCode,
+  queueName: NonEmptyString
+});
+export type EnqueueProfileCreationEventActivityInput = t.TypeOf<
+  typeof EnqueueProfileCreationEventActivityInput
+>;
+
+type IEnqueueProfileCreationEventActivityHandler = (
+  queueService: QueueServiceClient
+) => (context: Context, rawInput: unknown) => Promise<string>;
+
+export const GetEnqueueProfileCreationEventActivityHandler: IEnqueueProfileCreationEventActivityHandler = (
+  queueService: QueueServiceClient
+) => async (context: Context, rawInput: unknown): Promise<string> => {
+  const decodedInputOrError = EnqueueProfileCreationEventActivityInput.decode(
+    rawInput
+  );
+  if (decodedInputOrError.isLeft()) {
+    context.log.error(
+      `EnqueueProfileCreationEventActivity|Cannot parse input|ERROR=${readableReport(
+        decodedInputOrError.value
+      )}`
+    );
+    return "FAILURE";
+  }
+  return tryCatch(
+    () =>
+      queueService
+        .getQueueClient(decodedInputOrError.value.queueName)
+        // Default message TTL is 7 days @ref https://docs.microsoft.com/it-it/azure/storage/queues/storage-nodejs-how-to-use-queues?tabs=javascript#queue-service-concepts
+        .sendMessage(decodedInputOrError.value.fiscalCode),
+    err => {
+      context.log.error(
+        `EnqueueProfileCreationEventActivity|Cannot send a message to the queue ${
+          decodedInputOrError.value.queueName
+        }|ERROR=${JSON.stringify(err)}`
+      );
+    }
+  )
+    .map(() => "SUCCESS")
+    .getOrElseL(err => {
+      throw new Error(`TRANSIENT ERROR|${err}`);
+    })
+    .run();
+};

--- a/EnqueueProfileCreationEventActivity/handler.ts
+++ b/EnqueueProfileCreationEventActivity/handler.ts
@@ -1,9 +1,9 @@
 import { Context } from "@azure/functions";
 import { QueueServiceClient } from "@azure/storage-queue";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
-import { readableReport } from "italia-ts-commons/lib/reporters";
-import { FiscalCode, NonEmptyString } from "italia-ts-commons/lib/strings";
 
 export const EnqueueProfileCreationEventActivityInput = t.interface({
   fiscalCode: FiscalCode,

--- a/EnqueueProfileCreationEventActivity/index.ts
+++ b/EnqueueProfileCreationEventActivity/index.ts
@@ -3,12 +3,12 @@ import { getConfigOrThrow } from "../utils/config";
 import { GetEnqueueProfileCreationEventActivityHandler } from "./handler";
 
 const config = getConfigOrThrow();
-const queueServiceClient = QueueServiceClient.fromConnectionString(
-  config.QueueStorageConnection
+const eventsQueueServiceClient = QueueServiceClient.fromConnectionString(
+  config.EventsQueueStorageConnection
 );
 
 const activityFunction = GetEnqueueProfileCreationEventActivityHandler(
-  queueServiceClient
+  eventsQueueServiceClient
 );
 
 export default activityFunction;

--- a/EnqueueProfileCreationEventActivity/index.ts
+++ b/EnqueueProfileCreationEventActivity/index.ts
@@ -1,0 +1,14 @@
+import { QueueServiceClient } from "@azure/storage-queue";
+import { getConfigOrThrow } from "../utils/config";
+import { GetEnqueueProfileCreationEventActivityHandler } from "./handler";
+
+const config = getConfigOrThrow();
+const queueServiceClient = QueueServiceClient.fromConnectionString(
+  config.QueueStorageConnection
+);
+
+const activityFunction = GetEnqueueProfileCreationEventActivityHandler(
+  queueServiceClient
+);
+
+export default activityFunction;

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -2,6 +2,7 @@
 
 import * as df from "durable-functions";
 import { Task } from "durable-functions/lib/src/classes";
+import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
@@ -48,7 +49,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: [],
       sendCashbackMessage: false
     })(contextMockWithDf as any);
 
@@ -102,7 +102,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: [],
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -197,7 +196,9 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: [expectedQueueName],
+      notifyOn: ([expectedQueueName] as unknown) as NonEmptyArray<
+        NonEmptyString
+      >,
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -1,9 +1,9 @@
 /* tslint:disable:no-any */
 
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import * as df from "durable-functions";
 import { Task } from "durable-functions/lib/src/classes";
 import { fromArray } from "fp-ts/lib/NonEmptyArray";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
   aEmailChanged,

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -2,7 +2,7 @@
 
 import * as df from "durable-functions";
 import { Task } from "durable-functions/lib/src/classes";
-import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
+import { fromArray } from "fp-ts/lib/NonEmptyArray";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
@@ -196,9 +196,7 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: ([expectedQueueName] as unknown) as NonEmptyArray<
-        NonEmptyString
-      >,
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-any */
 
 import * as df from "durable-functions";
+import { Task } from "durable-functions/lib/src/classes";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
@@ -182,6 +183,9 @@ describe("UpsertedProfileOrchestrator", () => {
     const contextMockWithDf = {
       ...contextMock,
       df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
         callActivityWithRetry: jest
           .fn()
           .mockReturnValueOnce(sendWelcomeMessagesActivityResult),

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:no-any */
 
 import * as df from "durable-functions";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
   aEmailChanged,
@@ -22,6 +23,7 @@ const someRetryOptions = new df.RetryOptions(5000, 10);
 // tslint:disable-next-line: no-object-mutation
 someRetryOptions.backoffCoefficient = 1.5;
 
+// tslint:disable-next-line: no-big-function
 describe("UpsertedProfileOrchestrator", () => {
   it("should not start the EmailValidationProcessOrchestrator if the email is not changed", () => {
     const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
@@ -45,6 +47,7 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: [],
       sendCashbackMessage: false
     })(contextMockWithDf as any);
 
@@ -98,6 +101,7 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: [],
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -139,6 +143,108 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         messageKind: "CASHBACK",
         profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+  });
+
+  it("should enqueue a message if the notifyOn queue name is provided when an inbox become enabled", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true // Enable inbox to start the SendWelcomeMessagesActivity
+        },
+        oldProfile: aRetrievedProfile,
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: [expectedQueueName],
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    orchestratorHandler.next();
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
       }
     );
   });

--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -18,8 +18,8 @@ import {
 import { Input as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/index";
 import { diffBlockedServices } from "../utils/profiles";
 
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
-import { NonEmptyString } from "italia-ts-commons/lib/strings";
 import { EnqueueProfileCreationEventActivityInput } from "../EnqueueProfileCreationEventActivity/handler";
 import { ActivityInput as SendWelcomeMessageActivityInput } from "../SendWelcomeMessagesActivity/handler";
 

--- a/UpsertedProfileOrchestrator/index.ts
+++ b/UpsertedProfileOrchestrator/index.ts
@@ -8,7 +8,7 @@ const config = getConfigOrThrow();
 
 const orchestrator = df.orchestrator(
   getUpsertedProfileOrchestratorHandler({
-    notifyOn: config.IS_EUCOVIDCERT_ENABLED
+    notifyOn: config.FF_NEW_USERS_EUCOVIDCERT_ENABLED
       ? NonEmptyArray.fromArray([
           config.EUCOVIDCERT_NOTIFY_QUEUE_NAME
         ]).getOrElse(undefined)

--- a/UpsertedProfileOrchestrator/index.ts
+++ b/UpsertedProfileOrchestrator/index.ts
@@ -10,7 +10,7 @@ const orchestrator = df.orchestrator(
   getUpsertedProfileOrchestratorHandler({
     notifyOn: config.FF_NEW_USERS_EUCOVIDCERT_ENABLED
       ? NonEmptyArray.fromArray([
-          config.EUCOVIDCERT_NOTIFY_QUEUE_NAME
+          config.EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME
         ]).getOrElse(undefined)
       : undefined,
     sendCashbackMessage: config.IS_CASHBACK_ENABLED

--- a/UpsertedProfileOrchestrator/index.ts
+++ b/UpsertedProfileOrchestrator/index.ts
@@ -1,4 +1,5 @@
 ﻿import * as df from "durable-functions";
+import * as NonEmptyArray from "fp-ts/lib/NonEmptyArray";
 import { getConfigOrThrow } from "../utils/config";
 
 import { getUpsertedProfileOrchestratorHandler } from "./handler";
@@ -8,8 +9,10 @@ const config = getConfigOrThrow();
 const orchestrator = df.orchestrator(
   getUpsertedProfileOrchestratorHandler({
     notifyOn: config.IS_EUCOVIDCERT_ENABLED
-      ? [config.EUCOVIDCERT_NOTIFY_QUEUE_NAME]
-      : [],
+      ? NonEmptyArray.fromArray([
+          config.EUCOVIDCERT_NOTIFY_QUEUE_NAME
+        ]).getOrElse(undefined)
+      : undefined,
     sendCashbackMessage: config.IS_CASHBACK_ENABLED
   })
 );

--- a/UpsertedProfileOrchestrator/index.ts
+++ b/UpsertedProfileOrchestrator/index.ts
@@ -7,6 +7,9 @@ const config = getConfigOrThrow();
 
 const orchestrator = df.orchestrator(
   getUpsertedProfileOrchestratorHandler({
+    notifyOn: config.IS_EUCOVIDCERT_ENABLED
+      ? [config.EUCOVIDCERT_NOTIFY_QUEUE_NAME]
+      : [],
     sendCashbackMessage: config.IS_CASHBACK_ENABLED
   })
 );

--- a/env.example
+++ b/env.example
@@ -10,6 +10,7 @@ NODE_ENV=dev
 PUBLIC_API_KEY=key
 PUBLIC_API_URL=url
 QueueStorageConnection=foobar
+EventsQueueStorageConnection=foobar
 REQ_SERVICE_ID=req_id_dev
 SPID_BLOB_CONTAINER_NAME=spidblob
 SPID_BLOB_STORAGE_CONNECTION_STRING=foobar

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "@azure/cosmos": "^3.7.2",
+    "@azure/storage-queue": "^12.4.0",
     "@pagopa/io-functions-commons": "^20.4.0",
     "@pagopa/ts-commons": "^9.4.0",
     "abort-controller": "^3.0.0",

--- a/tslint.json
+++ b/tslint.json
@@ -7,5 +7,10 @@
   "rules": {
     "no-submodule-imports": false
   },
-  "rulesDirectory": []
+  "rulesDirectory": [],
+  "linterOptions": {
+    "exclude": [
+      "./generated/**/*"
+    ]
+  }
 }

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -44,6 +44,17 @@ export const ReqServiceIdConfig = t.union([
   })
 ]);
 
+export const EUCovidCertProfileQueueConfig = t.union([
+  t.interface({
+    EUCOVIDCERT_NOTIFY_QUEUE_NAME: NonEmptyString,
+    IS_EUCOVIDCERT_ENABLED: t.literal(true)
+  }),
+  t.interface({ IS_EUCOVIDCERT_ENABLED: t.literal(false) })
+]);
+export type EUCovidCertProfileQueueConfig = t.TypeOf<
+  typeof EUCovidCertProfileQueueConfig
+>;
+
 // global app configuration
 export type IConfig = t.TypeOf<typeof IConfig>;
 export const IConfig = t.intersection([
@@ -65,13 +76,15 @@ export const IConfig = t.intersection([
     SUBSCRIPTIONS_FEED_TABLE: NonEmptyString,
 
     IS_CASHBACK_ENABLED: t.boolean,
+    IS_EUCOVIDCERT_ENABLED: t.boolean,
 
     FF_ONLY_NATIONAL_SERVICES: t.boolean,
 
     isProduction: t.boolean
   }),
   MailerConfig,
-  ReqServiceIdConfig
+  ReqServiceIdConfig,
+  EUCovidCertProfileQueueConfig
 ]);
 
 // No need to re-evaluate this object for each call
@@ -81,6 +94,9 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
     .map(_ => _.toLocaleLowerCase() === "true")
     .getOrElse(false),
   IS_CASHBACK_ENABLED: fromNullable(process.env.IS_CASHBACK_ENABLED)
+    .map(_ => _.toLocaleLowerCase() === "true")
+    .getOrElse(false),
+  IS_EUCOVIDCERT_ENABLED: fromNullable(process.env.IS_EUCOVIDCERT_ENABLED)
     .map(_ => _.toLocaleLowerCase() === "true")
     .getOrElse(false),
   isProduction: process.env.NODE_ENV === "production"

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -46,7 +46,7 @@ export const ReqServiceIdConfig = t.union([
 
 export const EUCovidCertProfileQueueConfig = t.union([
   t.interface({
-    EUCOVIDCERT_NOTIFY_QUEUE_NAME: NonEmptyString,
+    EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME: NonEmptyString,
     FF_NEW_USERS_EUCOVIDCERT_ENABLED: t.literal(true)
   }),
   t.interface({ FF_NEW_USERS_EUCOVIDCERT_ENABLED: t.literal(false) })

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -47,9 +47,9 @@ export const ReqServiceIdConfig = t.union([
 export const EUCovidCertProfileQueueConfig = t.union([
   t.interface({
     EUCOVIDCERT_NOTIFY_QUEUE_NAME: NonEmptyString,
-    IS_EUCOVIDCERT_ENABLED: t.literal(true)
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED: t.literal(true)
   }),
-  t.interface({ IS_EUCOVIDCERT_ENABLED: t.literal(false) })
+  t.interface({ FF_NEW_USERS_EUCOVIDCERT_ENABLED: t.literal(false) })
 ]);
 export type EUCovidCertProfileQueueConfig = t.TypeOf<
   typeof EUCovidCertProfileQueueConfig
@@ -77,8 +77,8 @@ export const IConfig = t.intersection([
     SUBSCRIPTIONS_FEED_TABLE: NonEmptyString,
 
     IS_CASHBACK_ENABLED: t.boolean,
-    IS_EUCOVIDCERT_ENABLED: t.boolean,
 
+    FF_NEW_USERS_EUCOVIDCERT_ENABLED: t.boolean,
     FF_ONLY_NATIONAL_SERVICES: t.boolean,
 
     isProduction: t.boolean
@@ -91,13 +91,15 @@ export const IConfig = t.intersection([
 // No need to re-evaluate this object for each call
 const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
   ...process.env,
+  FF_NEW_USERS_EUCOVIDCERT_ENABLED: fromNullable(
+    process.env.FF_NEW_USERS_EUCOVIDCERT_ENABLED
+  )
+    .map(_ => _.toLocaleLowerCase() === "true")
+    .getOrElse(false),
   FF_ONLY_NATIONAL_SERVICES: fromNullable(process.env.FF_ONLY_NATIONAL_SERVICES)
     .map(_ => _.toLocaleLowerCase() === "true")
     .getOrElse(false),
   IS_CASHBACK_ENABLED: fromNullable(process.env.IS_CASHBACK_ENABLED)
-    .map(_ => _.toLocaleLowerCase() === "true")
-    .getOrElse(false),
-  IS_EUCOVIDCERT_ENABLED: fromNullable(process.env.IS_EUCOVIDCERT_ENABLED)
     .map(_ => _.toLocaleLowerCase() === "true")
     .getOrElse(false),
   isProduction: process.env.NODE_ENV === "production"

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -70,6 +70,7 @@ export const IConfig = t.intersection([
     PUBLIC_API_KEY: NonEmptyString,
     PUBLIC_API_URL: NonEmptyString,
 
+    EventsQueueStorageConnection: NonEmptyString,
     QueueStorageConnection: NonEmptyString,
 
     SPID_LOGS_PUBLIC_KEY: NonEmptyString,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     tslib "^2.0.0"
 
+"@azure/core-asynciterator-polyfill@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz#dcccebb88406e5c76e0e1d52e8cc4c43a68b3ee7"
+  integrity sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg==
+
 "@azure/core-auth@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@azure/core-auth/-/core-auth-1.3.0.tgz#0d55517cf0650aefe755669aca8a2f3724fcf536"
@@ -16,6 +21,34 @@
   dependencies:
     "@azure/abort-controller" "^1.0.0"
     tslib "^2.0.0"
+
+"@azure/core-http@^1.2.0":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@azure/core-http/-/core-http-1.2.4.tgz#7de543f349de2c1033321252debdee4642c398f9"
+  integrity sha512-cNumz3ckyFZY5zWOgcTHSO7AKRVwxbodG8WfcEGcdH+ZJL3KvJEI/vN58H6xk5v3ijulU2x/WPGJqrMVvcI79A==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-asynciterator-polyfill" "^1.0.0"
+    "@azure/core-auth" "^1.3.0"
+    "@azure/core-tracing" "1.0.0-preview.11"
+    "@azure/logger" "^1.0.0"
+    "@types/node-fetch" "^2.5.0"
+    "@types/tunnel" "^0.0.1"
+    form-data "^3.0.0"
+    node-fetch "^2.6.0"
+    process "^0.11.10"
+    tough-cookie "^4.0.0"
+    tslib "^2.0.0"
+    tunnel "^0.0.6"
+    uuid "^8.3.0"
+    xml2js "^0.4.19"
+
+"@azure/core-paging@^1.1.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@azure/core-paging/-/core-paging-1.1.3.tgz#3587c9898a0530cacb64bab216d7318468aa5efc"
+  integrity sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==
+  dependencies:
+    "@azure/core-asynciterator-polyfill" "^1.0.0"
 
 "@azure/core-rest-pipeline@^1.0.3":
   version "1.0.4"
@@ -31,6 +64,15 @@
     https-proxy-agent "^5.0.0"
     tslib "^2.0.0"
     uuid "^8.3.0"
+
+"@azure/core-tracing@1.0.0-preview.10":
+  version "1.0.0-preview.10"
+  resolved "https://registry.yarnpkg.com/@azure/core-tracing/-/core-tracing-1.0.0-preview.10.tgz#e7060272145dddad4486765030d1b037cd52a8ea"
+  integrity sha512-iIwjtMwQnsxB7cYkugMx+s4W1nfy3+pT/ceo+uW1fv4YDgYe84nh+QP0fEC9IH/3UATLSWbIBemdMHzk2APUrw==
+  dependencies:
+    "@opencensus/web-types" "0.0.7"
+    "@opentelemetry/api" "^0.10.2"
+    tslib "^2.0.0"
 
 "@azure/core-tracing@1.0.0-preview.11":
   version "1.0.0-preview.11"
@@ -73,6 +115,19 @@
   resolved "https://registry.yarnpkg.com/@azure/logger/-/logger-1.0.2.tgz#ad2d06478eeda7835f53def7e4566981b47d9787"
   integrity sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==
   dependencies:
+    tslib "^2.0.0"
+
+"@azure/storage-queue@^12.4.0":
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-queue/-/storage-queue-12.4.0.tgz#49ef9c27ec90ae458c21b865c64ee0c1da7e520a"
+  integrity sha512-QG5yxb+O0nMoNEbWWkOSijF3uIlStmGKqEpwL+OKCj1oqIh8Aa//M96+id2+u6TYs345kMd77APhtf2Ab7YELA==
+  dependencies:
+    "@azure/abort-controller" "^1.0.0"
+    "@azure/core-http" "^1.2.0"
+    "@azure/core-paging" "^1.1.1"
+    "@azure/core-tracing" "1.0.0-preview.10"
+    "@azure/logger" "^1.0.0"
+    "@opentelemetry/api" "^0.10.2"
     tslib "^2.0.0"
 
 "@babel/code-frame@^7.0.0":
@@ -428,6 +483,18 @@
   resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-1.0.0-rc.0.tgz#0c7c3f5e1285f99cedb563d74ad1adb9822b5144"
   integrity sha512-iXKByCMfrlO5S6Oh97BuM56tM2cIBB0XsL/vWF/AtJrJEKx4MC/Xdu0xDsGXMGcNWpqF7ujMsjjnp0+UHBwnDQ==
 
+"@opentelemetry/api@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/api/-/api-0.10.2.tgz#9647b881f3e1654089ff7ea59d587b2d35060654"
+  integrity sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==
+  dependencies:
+    "@opentelemetry/context-base" "^0.10.2"
+
+"@opentelemetry/context-base@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@opentelemetry/context-base/-/context-base-0.10.2.tgz#55bea904b2b91aa8a8675df9eaba5961bddb1def"
+  integrity sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw==
+
 "@pagopa/io-functions-commons@^20.4.0":
   version "20.4.0"
   resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-20.4.0.tgz#0aa826462d0af5f3177c997e9727a97b0d25b407"
@@ -659,7 +726,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.4.tgz#f0ec25dbf2f0e4b18647313ac031134ca5b24b21"
   integrity sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==
 
-"@types/node-fetch@^2.5.6":
+"@types/node-fetch@^2.5.0", "@types/node-fetch@^2.5.6":
   version "2.5.10"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz#9b4d4a0425562f9fcea70b12cb3fcdd946ca8132"
   integrity sha512-IpkX0AasN44hgEad0gEF/V6EgR5n69VEqPEgnmoM8GsIGro3PowbWs4tR6IhxUTyPLpOn+fiGG6nrQhcmoCuIQ==
@@ -716,6 +783,13 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
   integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
+
+"@types/tunnel@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@types/tunnel/-/tunnel-0.0.1.tgz#0d72774768b73df26f25df9184273a42da72b19c"
+  integrity sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==
+  dependencies:
+    "@types/node" "*"
 
 "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -6276,6 +6350,11 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
+process@^0.11.10:
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
+  integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
 progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -6326,6 +6405,11 @@ psl@^1.1.28:
   version "1.1.33"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.33.tgz#5533d9384ca7aab86425198e10e8053ebfeab661"
   integrity sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==
+
+psl@^1.1.33:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
+  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -6881,7 +6965,7 @@ sax@0.5.x:
   resolved "https://registry.yarnpkg.com/sax/-/sax-0.5.8.tgz#d472db228eb331c2506b0e8c15524adb939d12c1"
   integrity sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=
 
-sax@^1.2.1, sax@^1.2.4:
+sax@>=0.6.0, sax@^1.2.1, sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -7501,6 +7585,15 @@ tough-cookie@^2.3.2, tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tough-cookie@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
+  integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.1.2"
+
 tough-cookie@~2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
@@ -7683,6 +7776,11 @@ tunnel@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.5.tgz#d1532254749ed36620fcd1010865495a1fa9d0ae"
   integrity sha512-gj5sdqherx4VZKMcBA4vewER7zdK25Td+z1npBqpbDys4eJrLx+SlYjJvq1bDXs2irkuJM5pf8ktaEQVipkrbA==
+
+tunnel@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
@@ -7869,7 +7967,7 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
-universalify@^0.1.0:
+universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
@@ -8216,10 +8314,23 @@ xml2js@0.2.8:
   dependencies:
     sax "0.5.x"
 
+xml2js@^0.4.19:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.23.tgz#a0c69516752421eb2ac758ee4d4ccf58843eac66"
+  integrity sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "~11.0.0"
+
 xmlbuilder@^9.0.7:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+xmlbuilder@~11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
+  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xtend@^4.0.0, xtend@^4.0.1, xtend@^4.0.2, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. New `EnqueueProfileCreationEventActivity`
2. `UpsertedProfileOrchestrator` call `EnqueueProfileCreationEventActivity` when a user profile is activated
3. New config with queue name and FF

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When a user profile is activated and ready to receive messages we send a message inside a queue. This operation enables other external operations.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test
io-mock

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Integration test with `io-mock`
