### PR TITLE
fix 404 reference url app_backend.yaml in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:coverage": "jest --coverage",
     "lint": "tslint -p .",
     "generate": "npm-run-all generate:backend:*",
-    "generate:backend:api-models": "shx rm -rf generated/backend && shx mkdir -p generated/backend && gen-api-models --strict 0 --api-spec https://raw.githubusercontent.com/pagopa/io-backend/IP-216--update-message-model/api_backend.yaml --out-dir generated/backend",
+    "generate:backend:api-models": "shx rm -rf generated/backend && shx mkdir -p generated/backend && gen-api-models --strict 0 --api-spec https://raw.githubusercontent.com/pagopa/io-backend/master/api_backend.yaml --out-dir generated/backend",
     "generate:backend:notification-models": "shx rm -rf generated/notifications && shx mkdir -p generated/notifications && gen-api-models --strict 0 --api-spec https://raw.githubusercontent.com/pagopa/io-backend/master/api_notifications.yaml --out-dir generated/notifications",
     "generate:backend:notification-hub": "shx rm -rf generated/notifications && shx mkdir -p generated/notifications && gen-api-models --strict 0 --api-spec https://raw.githubusercontent.com/pagopa/io-backend/master/notification_queue_messages.yaml --out-dir generated/notifications",
     "deploy": "npm run build && func azure functionapp publish agid-functions-app-test",


### PR DESCRIPTION
The old url ref to a resource no more available.
The only file app_backend.yaml is in io-backend repository, so I use this url.