### PR TITLE
[#IP-284] add timestamp check on profile for is_email_enabled

### DIFF
--- a/GetProfile/__tests__/handler.test.ts
+++ b/GetProfile/__tests__/handler.test.ts
@@ -2,6 +2,7 @@
 
 import { none, some } from "fp-ts/lib/Option";
 
+import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
 import { fromLeft } from "fp-ts/lib/IOEither";
 import { taskEither } from "fp-ts/lib/TaskEither";
 import {
@@ -11,15 +12,32 @@ import {
 } from "../../__mocks__/mocks";
 import { GetProfileHandler } from "../handler";
 
+const aTimestamp = 1625154182000;
+const aValidTimestampBeforeLimitRetrievedProfile = {
+  ...aRetrievedProfile,
+  _ts: aTimestamp
+};
+
+const aValidTimestampAfterLimitRetrievedProfile = {
+  ...aRetrievedProfile,
+  _ts: 1626018182000
+};
+const anEmailModeSwitchLimitDate = UTCISODateFromString.decode(
+  "2021-07-08T23:59:59Z"
+).getOrElse(new Date());
+
 describe("GetProfileHandler", () => {
   it("should find an existing profile", async () => {
     const profileModelMock = {
       findLastVersionByModelId: jest.fn(() => {
-        return taskEither.of(some(aRetrievedProfile));
+        return taskEither.of(some(aValidTimestampAfterLimitRetrievedProfile));
       })
     };
 
-    const getProfileHandler = GetProfileHandler(profileModelMock as any);
+    const getProfileHandler = GetProfileHandler(
+      profileModelMock as any,
+      anEmailModeSwitchLimitDate
+    );
 
     const response = await getProfileHandler(aFiscalCode);
 
@@ -32,6 +50,32 @@ describe("GetProfileHandler", () => {
     }
   });
 
+  it("should find an existing profile overwriting isEmailEnabled property if cosmos timestamp is before email mode switch limit date", async () => {
+    const profileModelMock = {
+      findLastVersionByModelId: jest.fn(() => {
+        return taskEither.of(some(aValidTimestampBeforeLimitRetrievedProfile));
+      })
+    };
+
+    const getProfileHandler = GetProfileHandler(
+      profileModelMock as any,
+      anEmailModeSwitchLimitDate
+    );
+
+    const response = await getProfileHandler(aFiscalCode);
+
+    expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalledWith([
+      aFiscalCode
+    ]);
+    expect(response.kind).toBe("IResponseSuccessJson");
+    if (response.kind === "IResponseSuccessJson") {
+      expect(response.value).toEqual({
+        ...aExtendedProfile,
+        is_email_enabled: false
+      });
+    }
+  });
+
   it("should respond with NotFound if profile does not exist", async () => {
     const profileModelMock = {
       findLastVersionByModelId: jest.fn(() => {
@@ -39,7 +83,10 @@ describe("GetProfileHandler", () => {
       })
     };
 
-    const getProfileHandler = GetProfileHandler(profileModelMock as any);
+    const getProfileHandler = GetProfileHandler(
+      profileModelMock as any,
+      anEmailModeSwitchLimitDate
+    );
 
     const response = await getProfileHandler(aFiscalCode);
     expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalledWith([
@@ -55,7 +102,10 @@ describe("GetProfileHandler", () => {
       })
     };
 
-    const getProfileHandler = GetProfileHandler(profileModelMock as any);
+    const getProfileHandler = GetProfileHandler(
+      profileModelMock as any,
+      anEmailModeSwitchLimitDate
+    );
 
     const result = await getProfileHandler(aFiscalCode);
 

--- a/GetProfile/__tests__/handler.test.ts
+++ b/GetProfile/__tests__/handler.test.ts
@@ -29,7 +29,7 @@ describe("GetProfileHandler", () => {
   it("should find an existing profile", async () => {
     const profileModelMock = {
       findLastVersionByModelId: jest.fn(() => {
-        return taskEither.of(some(aValidTimestampAfterLimitRetrievedProfile));
+        return taskEither.of(some(aRetrievedProfileWithTimestampAfterLimit));
       })
     };
 
@@ -52,7 +52,7 @@ describe("GetProfileHandler", () => {
   it("should find an existing profile overwriting isEmailEnabled property if cosmos timestamp is before email mode switch limit date", async () => {
     const profileModelMock = {
       findLastVersionByModelId: jest.fn(() => {
-        return taskEither.of(some(aValidTimestampBeforeLimitRetrievedProfile));
+        return taskEither.of(some(aRetrievedProfileWithTimestampBeforeLimit));
       })
     };
 

--- a/GetProfile/__tests__/handler.test.ts
+++ b/GetProfile/__tests__/handler.test.ts
@@ -12,19 +12,18 @@ import {
 } from "../../__mocks__/mocks";
 import { GetProfileHandler } from "../handler";
 
-const aTimestamp = 1625154182000;
-const aValidTimestampBeforeLimitRetrievedProfile = {
+const anEmailModeSwitchLimitDate = UTCISODateFromString.decode(
+  "2021-07-08T23:59:59Z"
+).getOrElseL(() => fail("wrong date value"));
+const aTimestamp = anEmailModeSwitchLimitDate.valueOf();
+const aRetrievedProfileWithTimestampBeforeLimit = {
+  ...aRetrievedProfile,
+  _ts: aTimestamp - 1
+};
+const aRetrievedProfileWithTimestampAfterLimit = {
   ...aRetrievedProfile,
   _ts: aTimestamp
 };
-
-const aValidTimestampAfterLimitRetrievedProfile = {
-  ...aRetrievedProfile,
-  _ts: 1626018182000
-};
-const anEmailModeSwitchLimitDate = UTCISODateFromString.decode(
-  "2021-07-08T23:59:59Z"
-).getOrElse(new Date());
 
 describe("GetProfileHandler", () => {
   it("should find an existing profile", async () => {

--- a/GetProfile/handler.ts
+++ b/GetProfile/handler.ts
@@ -21,7 +21,7 @@ import {
 } from "@pagopa/ts-commons/lib/responses";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 
-import * as date_fns from "date-fns";
+import { isBefore } from "date-fns";
 import { retrievedProfileToExtendedProfile } from "../utils/profiles";
 
 type IGetProfileHandlerResult =
@@ -56,7 +56,7 @@ export function GetProfileHandler(
           maybeProfile
             .map(_ =>
               // if profile's timestamp is before email mode switch limit date we must force isEmailEnabled to false
-              date_fns.isBefore(_._ts, emailModeSwitchLimitDate)
+              isBefore(_._ts, emailModeSwitchLimitDate)
                 ? { ..._, isEmailEnabled: false }
                 : _
             )

--- a/GetProfile/handler.ts
+++ b/GetProfile/handler.ts
@@ -21,6 +21,7 @@ import {
 } from "@pagopa/ts-commons/lib/responses";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 
+import * as date_fns from "date-fns";
 import { retrievedProfileToExtendedProfile } from "../utils/profiles";
 
 type IGetProfileHandlerResult =
@@ -42,7 +43,8 @@ type IGetProfileHandler = (
  * Return a type safe GetProfile handler.
  */
 export function GetProfileHandler(
-  profileModel: ProfileModel
+  profileModel: ProfileModel,
+  emailModeSwitchLimitDate: Date
 ): IGetProfileHandler {
   return async fiscalCode =>
     profileModel
@@ -51,14 +53,21 @@ export function GetProfileHandler(
         failure =>
           ResponseErrorQuery("Error while retrieving the profile", failure),
         maybeProfile =>
-          maybeProfile.fold<IGetProfileHandlerResult>(
-            ResponseErrorNotFound(
-              "Profile not found",
-              "The profile you requested was not found in the system."
-            ),
-            profile =>
-              ResponseSuccessJson(retrievedProfileToExtendedProfile(profile))
-          )
+          maybeProfile
+            .map(_ =>
+              // if profile's timestamp is before email mode switch limit date we must force isEmailEnabled to false
+              date_fns.isBefore(_._ts, emailModeSwitchLimitDate)
+                ? { ..._, isEmailEnabled: false }
+                : _
+            )
+            .fold<IGetProfileHandlerResult>(
+              ResponseErrorNotFound(
+                "Profile not found",
+                "The profile you requested was not found in the system."
+              ),
+              profile =>
+                ResponseSuccessJson(retrievedProfileToExtendedProfile(profile))
+            )
       )
       .run();
 }
@@ -66,8 +75,11 @@ export function GetProfileHandler(
 /**
  * Wraps a GetProfile handler inside an Express request handler.
  */
-export function GetProfile(profileModel: ProfileModel): express.RequestHandler {
-  const handler = GetProfileHandler(profileModel);
+export function GetProfile(
+  profileModel: ProfileModel,
+  emailModeSwitchLimitDate: Date
+): express.RequestHandler {
+  const handler = GetProfileHandler(profileModel, emailModeSwitchLimitDate);
 
   const middlewaresWrap = withRequestMiddlewares(FiscalCodeMiddleware);
   return wrapRequestHandler(middlewaresWrap(handler));

--- a/GetProfile/index.ts
+++ b/GetProfile/index.ts
@@ -12,9 +12,11 @@ import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middl
 
 import createAzureFunctionHandler from "io-functions-express/dist/src/createAzureFunctionsHandler";
 
+import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 import { GetProfile } from "./handler";
 
+const config = getConfigOrThrow();
 // Setup Express
 const app = express();
 secureExpressApp(app);
@@ -23,7 +25,10 @@ const profileModel = new ProfileModel(
   cosmosdbInstance.container(PROFILE_COLLECTION_NAME)
 );
 
-app.get("/api/v1/profiles/:fiscalcode", GetProfile(profileModel));
+app.get(
+  "/api/v1/profiles/:fiscalcode",
+  GetProfile(profileModel, config.EMAIL_MODE_SWITCH_LIMIT_DATE)
+);
 
 const azureFunctionHandler = createAzureFunctionHandler(app);
 

--- a/StoreSpidLogs/handler.ts
+++ b/StoreSpidLogs/handler.ts
@@ -1,0 +1,78 @@
+import { Context } from "@azure/functions";
+import {
+  EncryptedPayload,
+  toEncryptedPayload
+} from "@pagopa/ts-commons/lib/encrypt";
+import { IPString, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { curry } from "fp-ts/lib/function";
+import * as t from "io-ts";
+import { SpidMsgItem } from "./index";
+
+import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import { sequenceS } from "fp-ts/lib/Apply";
+import { either } from "fp-ts/lib/Either";
+
+/**
+ * Payload of the stored blob item
+ * (one for each SPID request or response).
+ */
+const SpidBlobItem = t.interface({
+  // Timestamp of Request/Response creation
+  createdAt: UTCISODateFromString,
+
+  // IP of the client that made a SPID login action
+  ip: IPString,
+
+  // XML payload of the SPID Request
+  encryptedRequestPayload: EncryptedPayload,
+
+  // XML payload of the SPID Response
+  encryptedResponsePayload: EncryptedPayload,
+
+  // SPID request ID
+  spidRequestId: t.string
+});
+
+export type SpidBlobItem = t.TypeOf<typeof SpidBlobItem>;
+
+export interface IOutputBinding {
+  spidRequestResponse: SpidBlobItem;
+}
+
+export const encryptAndStore = async (
+  context: Context,
+  spidMsgItem: SpidMsgItem,
+  spidLogsPublicKey: NonEmptyString
+): Promise<void | IOutputBinding> => {
+  const encrypt = curry(toEncryptedPayload)(spidLogsPublicKey);
+  return sequenceS(either)({
+    encryptedRequestPayload: encrypt(spidMsgItem.requestPayload),
+    encryptedResponsePayload: encrypt(spidMsgItem.responsePayload)
+  })
+    .map(item => ({
+      ...spidMsgItem,
+      ...item
+    }))
+    .fold(
+      err =>
+        context.log.error(`StoreSpidLogs|ERROR=Cannot encrypt payload|${err}`),
+      (encryptedBlobItem: SpidBlobItem) =>
+        t
+          .exact(SpidBlobItem)
+          .decode(encryptedBlobItem)
+          .fold(
+            errs => {
+              // unrecoverable error
+              context.log.error(
+                `StoreSpidLogs|ERROR=Cannot decode payload|ERROR_DETAILS=${readableReport(
+                  errs
+                )}`
+              );
+            },
+            spidBlobItem => ({
+              spidRequestResponse: spidBlobItem
+            })
+          )
+    );
+};

--- a/StoreSpidLogs/index.ts
+++ b/StoreSpidLogs/index.ts
@@ -1,52 +1,21 @@
 import { Context } from "@azure/functions";
 
-import { sequenceS } from "fp-ts/lib/Apply";
-import { either } from "fp-ts/lib/Either";
-import { curry } from "fp-ts/lib/function";
 import * as t from "io-ts";
 
 import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
-import {
-  EncryptedPayload,
-  toEncryptedPayload
-} from "@pagopa/ts-commons/lib/encrypt";
-import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { IPString, PatternString } from "@pagopa/ts-commons/lib/strings";
+import { encryptAndStore } from "./handler";
 
 import { initTelemetryClient } from "../utils/appinsights";
 import { getConfigOrThrow } from "../utils/config";
 
 const config = getConfigOrThrow();
-const encrypt = curry(toEncryptedPayload)(config.SPID_LOGS_PUBLIC_KEY);
-
-/**
- * Payload of the stored blob item
- * (one for each SPID request or response).
- */
-const SpidBlobItem = t.interface({
-  // Timestamp of Request/Response creation
-  createdAt: UTCISODateFromString,
-
-  // IP of the client that made a SPID login action
-  ip: IPString,
-
-  // XML payload of the SPID Request
-  encryptedRequestPayload: EncryptedPayload,
-
-  // XML payload of the SPID Response
-  encryptedResponsePayload: EncryptedPayload,
-
-  // SPID request ID
-  spidRequestId: t.string
-});
-
-export type SpidBlobItem = t.TypeOf<typeof SpidBlobItem>;
 
 /**
  * Payload of the message retrieved from the queue
  * (one for each SPID request or response).
  */
-const SpidMsgItem = t.intersection([
+export const SpidMsgItem = t.intersection([
   t.interface({
     // Timestamp of Request/Response creation
     createdAt: UTCISODateFromString,
@@ -74,47 +43,11 @@ const SpidMsgItem = t.intersection([
 
 export type SpidMsgItem = t.TypeOf<typeof SpidMsgItem>;
 
-export interface IOutputBinding {
-  spidRequestResponse: SpidBlobItem;
-}
-
 // Initialize application insights
 initTelemetryClient();
 
 /**
  * Store SPID request / responses, read from a queue, into a blob storage.
  */
-export async function index(
-  context: Context,
-  spidMsgItem: SpidMsgItem
-): Promise<void | IOutputBinding> {
-  return sequenceS(either)({
-    encryptedRequestPayload: encrypt(spidMsgItem.requestPayload),
-    encryptedResponsePayload: encrypt(spidMsgItem.responsePayload)
-  })
-    .map(item => ({
-      ...spidMsgItem,
-      ...item
-    }))
-    .fold(
-      err =>
-        context.log.error(`StoreSpidLogs|ERROR=Cannot encrypt payload|${err}`),
-      (encryptedBlobItem: SpidBlobItem) =>
-        t
-          .exact(SpidBlobItem)
-          .decode(encryptedBlobItem)
-          .fold(
-            errs => {
-              // unrecoverable error
-              context.log.error(
-                `StoreSpidLogs|ERROR=Cannot decode payload|ERROR_DETAILS=${readableReport(
-                  errs
-                )}`
-              );
-            },
-            spidBlobItem => ({
-              spidRequestResponse: spidBlobItem
-            })
-          )
-    );
-}
+export const index = (context: Context, spidMsgItem: SpidMsgItem) =>
+  encryptAndStore(context, spidMsgItem, config.SPID_LOGS_PUBLIC_KEY);

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -5,7 +5,6 @@
  * The configuration is evaluate eagerly at the first access to the module. The module exposes convenient methods to access such value.
  */
 
-import { fromNullable as fromNullableE } from "fp-ts/lib/Either";
 import { fromNullable } from "fp-ts/lib/Option";
 import * as t from "io-ts";
 
@@ -14,7 +13,6 @@ import { MailerConfig } from "@pagopa/io-functions-commons/dist/src/mailer";
 import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { identity } from "fp-ts/lib/function";
 
 // exclude a specific value from a type
 // as strict equality is performed, allowed input types are constrained to be values not references (object, arrays, etc)

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -93,7 +93,7 @@ export const IConfig = t.intersection([
   EUCovidCertProfileQueueConfig
 ]);
 
-const DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE = new Date("1970-01-01T00:00:00Z");
+const DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE = "1970-01-01T00:00:00Z";
 
 // No need to re-evaluate this object for each call
 const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
@@ -106,7 +106,7 @@ const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
         () => DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE
       )
     )
-    .fold(identity, identity),
+    .fold(_ => new Date(_), identity),
   FF_NEW_USERS_EUCOVIDCERT_ENABLED: fromNullable(
     process.env.FF_NEW_USERS_EUCOVIDCERT_ENABLED
   )

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -10,6 +10,7 @@ import * as t from "io-ts";
 
 import { MailerConfig } from "@pagopa/io-functions-commons/dist/src/mailer";
 
+import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 
@@ -75,6 +76,8 @@ export const IConfig = t.intersection([
 
     SPID_LOGS_PUBLIC_KEY: NonEmptyString,
     SUBSCRIPTIONS_FEED_TABLE: NonEmptyString,
+
+    EMAIL_MODE_SWITCH_LIMIT_DATE: UTCISODateFromString,
 
     IS_CASHBACK_ENABLED: t.boolean,
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -98,15 +98,9 @@ const DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE = "1970-01-01T00:00:00Z";
 // No need to re-evaluate this object for each call
 const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
   ...process.env,
-  EMAIL_MODE_SWITCH_LIMIT_DATE: fromNullableE(
-    DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE
-  )(process.env.EMAIL_MODE_SWITCH_LIMIT_DATE)
-    .chain(_ =>
-      UTCISODateFromString.decode(_).mapLeft(
-        () => DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE
-      )
-    )
-    .fold(_ => new Date(_), identity),
+  EMAIL_MODE_SWITCH_LIMIT_DATE: fromNullable(
+    process.env.EMAIL_MODE_SWITCH_LIMIT_DATE
+  ).getOrElse(DEFAULT_EMAIL_MODE_SWITCH_LIMIT_DATE),
   FF_NEW_USERS_EUCOVIDCERT_ENABLED: fromNullable(
     process.env.FF_NEW_USERS_EUCOVIDCERT_ENABLED
   )


### PR DESCRIPTION
#### List of Changes
- Add `EMAIL_MODE_SWITCH_LIMIT_DATE` in config properties
- `GetProfile` returns isEmailEnabled set to false if profile timestamp is before a specific limit date (see previous bullet), otherwise return the value stored on cosmosdb
- Refactor on `StoreSpidLogs` function for better unit testing

#### Motivation and Context
We want that a citizen with an old profile, or even a profile that was upserted before the release limit date, has email notification turned off for default

#### How Has This Been Tested?
It has been tested by performing:
- yarn lint
- yarn test

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
