### PR TITLE
[#IP-297] Move `OPT_OUT_EMAIL_SWITCH_DATE` to Timestamp format

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@azure/cosmos": "^3.7.2",
     "@azure/storage-queue": "^12.4.0",
     "@pagopa/io-functions-commons": "^20.6.6",
-    "@pagopa/ts-commons": "^9.4.0",
+    "@pagopa/ts-commons": "^9.6.0",
     "abort-controller": "^3.0.0",
     "applicationinsights": "^1.7.4",
     "azure-storage": "^2.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,7 +536,7 @@
     write-yaml-file "^4.1.3"
     yargs "^11.1.0"
 
-"@pagopa/ts-commons@^9.2.0", "@pagopa/ts-commons@^9.4.0":
+"@pagopa/ts-commons@^9.2.0":
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-9.4.0.tgz#680ba8a43db4c0397e6c4e8f9cfd3d758cc0b30c"
   integrity sha512-eLuyLQPQsQArCHTfcLhtES8dan6GaJ99AfqbyZS8VsyZxuOZ0lyCZkFQBdd9QlmGUHXiEpLVjVEz+uXcGSnLUg==
@@ -554,6 +554,20 @@
   version "9.5.1"
   resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-9.5.1.tgz#a1285589265560a1a96b4d389da2e37f9209ec58"
   integrity sha512-Eqozj079y/oyLZwh6I/WBWsUKJ6rFOj5wGTXaYmVffxFHWXstQiSqw5S6cFAKK5/LA9lL9ro+zk3+lUKi+/Fow==
+  dependencies:
+    abort-controller "^3.0.0"
+    agentkeepalive "^4.1.4"
+    applicationinsights "^1.8.10"
+    fp-ts "1.17.4"
+    io-ts "1.8.5"
+    json-set-map "^1.1.2"
+    node-fetch "^2.6.0"
+    validator "^10.1.0"
+
+"@pagopa/ts-commons@^9.6.0":
+  version "9.6.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/ts-commons/-/ts-commons-9.6.0.tgz#dbc837e8afa0aa66ab174d49757321a9fe18e416"
+  integrity sha512-GrXz6qFtBeRPS7reVxLEze6OvHUNMlCp4Ksbqwijl8xdkXD9ETCgU+9nKjGSPS6fOz2pUIOuIcts72HX7wlGmA==
   dependencies:
     abort-controller "^3.0.0"
     agentkeepalive "^4.1.4"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
In order to make Date env variable compliant to App service issue we must to parse Date with Timestamp format
#### List of Changes
<!--- Describe your changes in detail -->
- Move `OPT_OUT_EMAIL_SWITCH_DATE` format to Timestamp
- Upgrade `@pagopa/ts-commons` package

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR allows us to use Timestamp format on Date env variable

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
