### PR TITLE
[#IP-298] Add Subscription feed update logic based on servicePreferenceSetting mode

### DIFF
--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -8,7 +8,9 @@ import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
   aEmailChanged,
   aFiscalCode,
-  aRetrievedProfile
+  aRetrievedProfile,
+  autoProfileServicePreferencesSettings,
+  manualProfileServicePreferencesSettings
 } from "../../__mocks__/mocks";
 import {
   OrchestratorInput as EmailValidationProcessOrchestratorInput,
@@ -19,6 +21,7 @@ import {
   OrchestratorInput as UpsertedProfileOrchestratorInput
 } from "../handler";
 
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
 import { readableReport } from "@pagopa/ts-commons/lib/reporters";
 
 const someRetryOptions = new df.RetryOptions(5000, 10);
@@ -242,6 +245,856 @@ describe("UpsertedProfileOrchestrator", () => {
     );
 
     orchestratorHandler.next();
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity when profile is created", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true // Enable inbox to start the SendWelcomeMessagesActivity
+        },
+        oldProfile: undefined,
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result4 = orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result5 = orchestratorHandler.next(result4.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "SUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    orchestratorHandler.next(result5.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should not call UpdateSubscriptionFeedActivity if oldProfile and newProfile have the same servicePreferenceMode", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    orchestratorHandler.next();
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toHaveBeenCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {}
+    );
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should not call UpdateSubscriptionFeedActivity switching from LEGACY to AUTO", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile
+        },
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    orchestratorHandler.next();
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toHaveBeenCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {}
+    );
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile from LEGACY to MANUAL", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: manualProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile
+        },
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result4 = orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result5 = orchestratorHandler.next(result4.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+    orchestratorHandler.next(result5.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from MANUAL to AUTOß", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: manualProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result4 = orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result5 = orchestratorHandler.next(result4.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+    orchestratorHandler.next(result5.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity to subscribe the entire profile switching from AUTO to MANUAL", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          servicePreferencesSettings: manualProfileServicePreferencesSettings
+        },
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result4 = orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result5 = orchestratorHandler.next(result4.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "SUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+    orchestratorHandler.next(result5.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity with the difference between blockedInboxOrchannels when servicePreferenceMode is LEGACY", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
+      {
+        newProfile: {
+          ...aRetrievedProfile,
+          blockedInboxOrChannels: {
+            service1: [BlockedInboxOrChannelEnum.INBOX],
+            service2: [BlockedInboxOrChannelEnum.INBOX]
+          },
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true // Enable inbox to start the SendWelcomeMessagesActivity
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          blockedInboxOrChannels: {
+            service3: [BlockedInboxOrChannelEnum.INBOX]
+          }
+        },
+        updatedAt: new Date()
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = EmailValidationProcessOrchestratorResult.decode(
+      {
+        kind: "SUCCESS"
+      }
+    ).getOrElseL(_ =>
+      fail(
+        `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+          _
+        )}`
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: fromArray([expectedQueueName]).getOrElseL(undefined),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    const result = orchestratorHandler.next();
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    const result2 = orchestratorHandler.next(result.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result3 = orchestratorHandler.next(result2.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result4 = orchestratorHandler.next(result3.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    const result5 = orchestratorHandler.next(result4.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "SUBSCRIBED",
+        serviceId: "service3",
+        subscriptionKind: "SERVICE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+    const result6 = orchestratorHandler.next(result5.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        serviceId: "service1",
+        subscriptionKind: "SERVICE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+    const result7 = orchestratorHandler.next(result6.value);
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        serviceId: "service2",
+        subscriptionKind: "SERVICE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    orchestratorHandler.next(result7.value);
     expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
       "EnqueueProfileCreationEventActivity",
       someRetryOptions,

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -830,7 +830,7 @@ describe("UpsertedProfileOrchestrator", () => {
     );
   });
 
-  it("should call UpdateSubscriptionFeedActivity to subscribe the entire profile switching from AUTO to MANUAL", async () => {
+  it("should call UpdateSubscriptionFeedActivity to subscribe the entire profile switching from MANUAL to AUTO", async () => {
     const expectedQueueName = "queue_name" as NonEmptyString;
     const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
       {

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -589,7 +589,7 @@ describe("UpsertedProfileOrchestrator", () => {
     );
   });
 
-  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile from LEGACY to MANUAL", async () => {
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from LEGACY to MANUAL", async () => {
     const expectedQueueName = "queue_name" as NonEmptyString;
     const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
       {
@@ -709,7 +709,7 @@ describe("UpsertedProfileOrchestrator", () => {
     );
   });
 
-  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from MANUAL to AUTOß", async () => {
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from MANUAL to AUTO", async () => {
     const expectedQueueName = "queue_name" as NonEmptyString;
     const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
       {

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -709,7 +709,7 @@ describe("UpsertedProfileOrchestrator", () => {
     );
   });
 
-  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from MANUAL to AUTO", async () => {
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from AUTO to MANUAL", async () => {
     const expectedQueueName = "queue_name" as NonEmptyString;
     const upsertedProfileOrchestratorInput = UpsertedProfileOrchestratorInput.decode(
       {

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -38,9 +38,11 @@ describe("UpsertedProfileOrchestrator", () => {
         oldProfile: aRetrievedProfile,
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -72,9 +74,11 @@ describe("UpsertedProfileOrchestrator", () => {
         oldProfile: aRetrievedProfile,
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -82,10 +86,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -160,9 +164,11 @@ describe("UpsertedProfileOrchestrator", () => {
         oldProfile: aRetrievedProfile,
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -170,10 +176,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -265,9 +271,11 @@ describe("UpsertedProfileOrchestrator", () => {
         },
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -275,10 +283,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -374,9 +382,11 @@ describe("UpsertedProfileOrchestrator", () => {
         },
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -384,10 +394,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -483,9 +493,11 @@ describe("UpsertedProfileOrchestrator", () => {
         },
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -493,10 +505,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -599,9 +611,11 @@ describe("UpsertedProfileOrchestrator", () => {
         },
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -609,10 +623,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -715,9 +729,11 @@ describe("UpsertedProfileOrchestrator", () => {
         },
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -725,10 +741,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );
@@ -836,9 +852,11 @@ describe("UpsertedProfileOrchestrator", () => {
         },
         updatedAt: new Date()
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
-        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(_)}`
+        `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+          errs
+        )}`
       )
     );
 
@@ -846,10 +864,10 @@ describe("UpsertedProfileOrchestrator", () => {
       {
         kind: "SUCCESS"
       }
-    ).getOrElseL(_ =>
+    ).getOrElseL(errs =>
       fail(
         `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
-          _
+          errs
         )}`
       )
     );

--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -204,8 +204,8 @@ export const getUpsertedProfileOrchestratorHandler = (params: {
       );
     } else {
       const { newServicePreferencesMode, oldServicePreferenceMode } = {
-        newServicePreferencesMode: newProfile.servicePreferencesSettings.mode.toString(),
-        oldServicePreferenceMode: oldProfile.servicePreferencesSettings.mode.toString()
+        newServicePreferencesMode: newProfile.servicePreferencesSettings.mode,
+        oldServicePreferenceMode: oldProfile.servicePreferencesSettings.mode
       };
 
       if (newServicePreferencesMode === ServicesPreferencesModeEnum.LEGACY) {
@@ -256,15 +256,13 @@ export const getUpsertedProfileOrchestratorHandler = (params: {
             } as UpdateServiceSubscriptionFeedActivityInput
           );
         }
-        // If Service Preference Mode doesn't change from oldProfile to newProfile in upsert operation
-        // or even if mode transition cause a no effect change (i.e from LEGACY to AUTO)
-        // we don't need to update Subscription Feed
+        // we need to update Subscription Feed on Profile Upsert when:
+        // Service Preference Mode has changed from oldProfile to newProfile in upsert operation
+        // and mode transition causes an effective change (i.e when NOT going from LEGACY to AUTO)
       } else if (
         oldServicePreferenceMode !== newServicePreferencesMode &&
-        !(
-          oldServicePreferenceMode === ServicesPreferencesModeEnum.LEGACY &&
-          newServicePreferencesMode === ServicesPreferencesModeEnum.AUTO
-        )
+        (oldServicePreferenceMode !== ServicesPreferencesModeEnum.LEGACY ||
+          newServicePreferencesMode !== ServicesPreferencesModeEnum.AUTO)
       ) {
         // | oldServicePreferenceMode | newServicePreferencesMode | Operation
         // -------------------------------------------------------------------------

--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -18,6 +18,10 @@ import {
 import { Input as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/index";
 import { diffBlockedServices } from "../utils/profiles";
 
+import {
+  ServicesPreferencesMode,
+  ServicesPreferencesModeEnum
+} from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
 import { EnqueueProfileCreationEventActivityInput } from "../EnqueueProfileCreationEventActivity/handler";
@@ -202,48 +206,91 @@ export const getUpsertedProfileOrchestratorHandler = (params: {
         } as UpdateServiceSubscriptionFeedActivityInput
       );
     } else {
-      // When the profile gets updates, we extract the services that have been
-      // blocked and unblocked during this profile update.
-      // Blocked services get mapped to unsubscribe events, while unblocked ones
-      // get mapped to subscribe events.
-      const {
-        e1: unsubscribedServices,
-        e2: subscribedServices
-      } = diffBlockedServices(
-        oldProfile.blockedInboxOrChannels,
-        newProfile.blockedInboxOrChannels
-      );
+      const { newServicePreferencesMode, oldServicePreferenceMode } = {
+        newServicePreferencesMode: newProfile.servicePreferencesSettings.mode.toString(),
+        oldServicePreferenceMode: oldProfile.servicePreferencesSettings.mode.toString()
+      };
 
-      for (const s of subscribedServices) {
+      if (newServicePreferencesMode === ServicesPreferencesModeEnum.LEGACY) {
+        // When a LEGACY profile gets updates, we extract the services that have been
+        // blocked and unblocked during this profile update.
+        // Blocked services get mapped to unsubscribe events, while unblocked ones
+        // get mapped to subscribe events.
+        const {
+          e1: unsubscribedServices,
+          e2: subscribedServices
+        } = diffBlockedServices(
+          oldProfile.blockedInboxOrChannels,
+          newProfile.blockedInboxOrChannels
+        );
+
+        for (const s of subscribedServices) {
+          context.log.verbose(
+            `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=SUBSCRIBED|SERVICE_ID=${s}`
+          );
+          yield context.df.callActivityWithRetry(
+            "UpdateSubscriptionsFeedActivity",
+            retryOptions,
+            {
+              fiscalCode: newProfile.fiscalCode,
+              operation: "SUBSCRIBED",
+              serviceId: s as ServiceId,
+              subscriptionKind: "SERVICE",
+              updatedAt: updatedAt.getTime(),
+              version: newProfile.version
+            } as UpdateServiceSubscriptionFeedActivityInput
+          );
+        }
+
+        for (const s of unsubscribedServices) {
+          context.log.verbose(
+            `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=UNSUBSCRIBED|SERVICE_ID=${s}`
+          );
+          yield context.df.callActivityWithRetry(
+            "UpdateSubscriptionsFeedActivity",
+            retryOptions,
+            {
+              fiscalCode: newProfile.fiscalCode,
+              operation: "UNSUBSCRIBED",
+              serviceId: s as ServiceId,
+              subscriptionKind: "SERVICE",
+              updatedAt: updatedAt.getTime(),
+              version: newProfile.version
+            } as UpdateServiceSubscriptionFeedActivityInput
+          );
+        }
+        // If Service Preference Mode doesn't change from oldProfile to newProfile in upsert operation
+        // or even if mode transition cause a no effect change (i.e from LEGACY to AUTO)
+        // we don't need to update Subscription Feed
+      } else if (
+        oldServicePreferenceMode !== newServicePreferencesMode &&
+        !(
+          oldServicePreferenceMode === ServicesPreferencesModeEnum.LEGACY &&
+          newServicePreferencesMode === ServicesPreferencesModeEnum.AUTO
+        )
+      ) {
+        // | oldServicePreferenceMode | newServicePreferencesMode | Operation
+        // -------------------------------------------------------------------------
+        // | LEGACY                   | MANUAL                    | UNSUBSCRIBED
+        // | AUTO                     | MANUAL                    | UNSUBSCRIBED
+        // | MANUAL                   | AUTO                      | SUBSCRIBED
+        // When a profile Service preference mode is upserted from AUTO or LEGACY to MANUAL
+        // we must unsubscribe th entire profile, otherwise from MANUAL we can update mode only to AUTO
+        // so we must subscribe the entire profile.
+        const feedOperation =
+          newServicePreferencesMode === ServicesPreferencesModeEnum.MANUAL
+            ? "UNSUBSCRIBED"
+            : "SUBSCRIBED";
         context.log.verbose(
-          `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=SUBSCRIBED|SERVICE_ID=${s}`
+          `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=${feedOperation}`
         );
         yield context.df.callActivityWithRetry(
           "UpdateSubscriptionsFeedActivity",
           retryOptions,
           {
             fiscalCode: newProfile.fiscalCode,
-            operation: "SUBSCRIBED",
-            serviceId: s as ServiceId,
-            subscriptionKind: "SERVICE",
-            updatedAt: updatedAt.getTime(),
-            version: newProfile.version
-          } as UpdateServiceSubscriptionFeedActivityInput
-        );
-      }
-
-      for (const s of unsubscribedServices) {
-        context.log.verbose(
-          `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=UNSUBSCRIBED|SERVICE_ID=${s}`
-        );
-        yield context.df.callActivityWithRetry(
-          "UpdateSubscriptionsFeedActivity",
-          retryOptions,
-          {
-            fiscalCode: newProfile.fiscalCode,
-            operation: "UNSUBSCRIBED",
-            serviceId: s as ServiceId,
-            subscriptionKind: "SERVICE",
+            operation: feedOperation,
+            subscriptionKind: "PROFILE",
             updatedAt: updatedAt.getTime(),
             version: newProfile.version
           } as UpdateServiceSubscriptionFeedActivityInput

--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -18,10 +18,7 @@ import {
 import { Input as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/index";
 import { diffBlockedServices } from "../utils/profiles";
 
-import {
-  ServicesPreferencesMode,
-  ServicesPreferencesModeEnum
-} from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
 import { EnqueueProfileCreationEventActivityInput } from "../EnqueueProfileCreationEventActivity/handler";

--- a/utils/durable.ts
+++ b/utils/durable.ts
@@ -1,0 +1,20 @@
+/**
+ * Util function that takes a generator and executes each step until is done.
+ * It is meant to be a test utility
+ *
+ * @param gen a generator function
+ * @returns the last value yielded by the generator
+ */
+export const consumeGenerator = <TReturn = unknown>(
+  gen: Generator<unknown, TReturn, unknown>
+): TReturn => {
+  // tslint:disable-next-line: no-let
+  let prevValue: unknown;
+  while (true) {
+    const { done, value } = gen.next(prevValue);
+    if (done) {
+      return value as TReturn;
+    }
+    prevValue = value;
+  }
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
In order to complete the opt-in/opt-out service model implementation, this PR implements changes on profile's upsert workflow, with particular focus on impacts through Subscription Feed update activities, needed when considering new profile's model involving `servicePreferenceSettingsMode`.
#### List of Changes
<!--- Describe your changes in detail -->
- Update UpsertProfileOrchestrator
- Add unit tests and refactor existing ones

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
New service model requires changes to Profile Upsert operations in order to be compliant with the new model, by maintaining backward compatibility.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
