### PR TITLE
[#IP-299] Add SubscriptionFeed Update on ServicePreference upsert

### DIFF
--- a/UpdateSubscriptionsFeedActivity/handler.ts
+++ b/UpdateSubscriptionsFeedActivity/handler.ts
@@ -1,0 +1,129 @@
+import { Context } from "@azure/functions";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { TableService } from "azure-storage";
+import * as crypto from "crypto";
+import * as t from "io-ts";
+import { updateSubscriptionStatus } from "../utils/subscription_feed";
+
+/**
+ * Input data for this activity function, we need information about the kind
+ * of subscription event and the affected user profile.
+ */
+const Input = t.intersection([
+  t.interface({
+    // fiscal code of the user affected by this update
+    fiscalCode: FiscalCode,
+    // whether the service has been subscribed or unsubscribed
+    operation: t.union([t.literal("SUBSCRIBED"), t.literal("UNSUBSCRIBED")]),
+    // the time (millis epoch) of the update
+    updatedAt: t.number,
+    // updated version of the profile
+    version: t.number
+  }),
+  t.union([
+    t.interface({
+      // a profile subscription event
+      subscriptionKind: t.literal("PROFILE")
+    }),
+    t.interface({
+      // the updated service
+      serviceId: ServiceId,
+      // a service subscription event
+      subscriptionKind: t.literal("SERVICE")
+    })
+  ])
+]);
+
+export type Input = t.TypeOf<typeof Input>;
+
+export const updateSubscriptionFeed = async (
+  context: Context,
+  rawInput: unknown,
+  tableService: TableService,
+  subscriptionFeedTableName: NonEmptyString,
+  logPrefix: string = "UpdateServiceSubscriptionFeedActivity"
+) => {
+  const decodedInputOrError = Input.decode(rawInput);
+  if (decodedInputOrError.isLeft()) {
+    context.log.error(
+      `${logPrefix}|Cannot parse input|ERROR=${readableReport(
+        decodedInputOrError.value
+      )}`
+    );
+    return "FAILURE";
+  }
+
+  const decodedInput = decodedInputOrError.value;
+
+  const { fiscalCode, operation, updatedAt, version } = decodedInput;
+
+  // The date part of the key will be in UTC time zone, with format: YYYY-MM-DD
+  const utcTodayPrefix = new Date(updatedAt).toISOString().substring(0, 10);
+
+  // Create a SHA256 hash of the fiscal code
+  // see https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options
+  const fiscalCodeHash = crypto
+    .createHash("sha256")
+    .update(fiscalCode)
+    .digest("hex");
+
+  const updateLogPrefix = `${logPrefix}|PROFILE=${fiscalCode}|OPERATION=${operation}|PROFILE=${fiscalCode}`;
+
+  // Entity keys have the following format
+  //
+  // Profile subscription events: P-<DATE>-<EVENT>-<HASH>
+  // Service subscription events: S-<DATE>-<SERVICE_ID>-<EVENT>-<HASH>
+  //
+  // Where:
+  //
+  // * DATE is "YYYY-MM-DD" (UTC)
+  // * SERVICE_ID is the service ID that the user subscribed/unsubscribed
+  // * EVENT is either "S" for subscription events or "U" for unsubscriptions
+  // * HASH is the hex encoded SHA256 hash of the fiscal code
+  //
+  const sPartitionKey =
+    decodedInput.subscriptionKind === "PROFILE"
+      ? `P-${utcTodayPrefix}-S`
+      : `S-${utcTodayPrefix}-${decodedInput.serviceId}-S`;
+  const uPartitionKey =
+    decodedInput.subscriptionKind === "PROFILE"
+      ? `P-${utcTodayPrefix}-U`
+      : `S-${utcTodayPrefix}-${decodedInput.serviceId}-U`;
+
+  const sKey = `${sPartitionKey}-${fiscalCodeHash}`;
+  const uKey = `${uPartitionKey}-${fiscalCodeHash}`;
+
+  const updateSubscriptionStatusHandler = updateSubscriptionStatus(
+    tableService,
+    subscriptionFeedTableName
+  );
+  if (operation === "SUBSCRIBED") {
+    // we delete the entry from the unsubscriptions and we add it to the
+    // subscriptions
+    await updateSubscriptionStatusHandler(
+      context,
+      updateLogPrefix,
+      version,
+      uPartitionKey,
+      uKey,
+      sPartitionKey,
+      sKey
+    );
+  } else {
+    // we delete the entry from the subscriptions and we add it to the
+    // unsubscriptions
+    await updateSubscriptionStatusHandler(
+      context,
+      updateLogPrefix,
+      version,
+      sPartitionKey,
+      sKey,
+      uPartitionKey,
+      uKey
+    );
+  }
+
+  return "SUCCESS";
+};

--- a/UpdateSubscriptionsFeedActivity/index.ts
+++ b/UpdateSubscriptionsFeedActivity/index.ts
@@ -1,221 +1,24 @@
-﻿import * as crypto from "crypto";
-
-import * as t from "io-ts";
-
-import { AzureFunction, Context } from "@azure/functions";
-import { createTableService, TableUtilities } from "azure-storage";
-
-import { readableReport } from "@pagopa/ts-commons/lib/reporters";
-import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
-
-import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
-
-import { isNone } from "fp-ts/lib/Option";
-import { deleteTableEntity, insertTableEntity } from "../utils/storage";
-
+﻿import { AzureFunction, Context } from "@azure/functions";
+import { createTableService } from "azure-storage";
 import { getConfigOrThrow } from "../utils/config";
+import { updateSubscriptionFeed } from "./handler";
 
 const config = getConfigOrThrow();
 
 const tableService = createTableService(config.QueueStorageConnection);
 
-const insertEntity = insertTableEntity(
-  tableService,
-  config.SUBSCRIPTIONS_FEED_TABLE
-);
-
-const deleteEntity = deleteTableEntity(
-  tableService,
-  config.SUBSCRIPTIONS_FEED_TABLE
-);
-
-const eg = TableUtilities.entityGenerator;
-
-/**
- * Input data for this activity function, we need information about the kind
- * of subscription event and the affected user profile.
- */
-const Input = t.intersection([
-  t.interface({
-    // fiscal code of the user affected by this update
-    fiscalCode: FiscalCode,
-    // whether the service has been subscribed or unsubscribed
-    operation: t.union([t.literal("SUBSCRIBED"), t.literal("UNSUBSCRIBED")]),
-    // the time (millis epoch) of the update
-    updatedAt: t.number,
-    // updated version of the profile
-    version: t.number
-  }),
-  t.union([
-    t.interface({
-      // a profile subscription event
-      subscriptionKind: t.literal("PROFILE")
-    }),
-    t.interface({
-      // the updated service
-      serviceId: ServiceId,
-      // a service subscription event
-      subscriptionKind: t.literal("SERVICE")
-    })
-  ])
-]);
-
-export type Input = t.TypeOf<typeof Input>;
-
 // When the function starts, attempt to create the table if it does not exist
 // Note that we cannot log anything just yet since we don't have a Context
 tableService.createTableIfNotExists(config.SUBSCRIPTIONS_FEED_TABLE, () => 0);
 
-/**
- * Updates the subscrption status of a user.
- *
- * User subscribed or unsubscribed events are stored as empty entities in an
- * Azure storage table.
- *
- * The entity key is composed by the day of the event, the service ID (if it's
- * a service subscription event), a character that indicates whether it's a
- * subscribed (S) or unsubscribed (U) event and the SHA256 hash of the fiscal
- * code of the user.
- *
- * For each day, (optionally) service and user, either the S or the U key exist,
- * but not both (it would not make sense).
- *
- * When the key does not include a service ID, it refers to a profile
- * subscription event, meaning the user registered to IO (subscribed) or deleted
- * her account (unsubscribed).
- * When the key includes the service ID, it refers to a service subscription
- * event, meaning the user activated (subscribed) or deactivated (unsubscribed)
- * a specific service.
- */
-async function updateSubscriptionStatus(
-  context: Context,
-  logPrefix: string,
-  version: number,
-  delPartitionKey: string,
-  delKey: string,
-  insPartitionKey: string,
-  insKey: string
-): Promise<true> {
-  // First we try to delete a previous (un)subscriptions operation
-  // from the subscription feed entries for the current day
-  context.log.verbose(`${logPrefix}|KEY=${delKey}|Deleting entity`);
-  const { e1: maybeError, e2: uResponse } = await deleteEntity({
-    PartitionKey: eg.String(delPartitionKey),
-    RowKey: eg.String(delKey)
-  });
-
-  // If deleteEntity is successful it means the user
-  // previously made an opposite choice (in the same day).
-  // Since we're going to expose only the delta for this day,
-  // and we've just deleted the opposite operation, we go on here.
-  if (isNone(maybeError)) {
-    return true;
-  }
-
-  if (maybeError.isSome() && uResponse.statusCode !== 404) {
-    // retry
-    context.log.error(`${logPrefix}|ERROR=${maybeError.value.message}`);
-    throw maybeError.value;
-  }
-
-  // If deleteEntity has not found any entry,
-  // we insert the new (un)subscription entry into the feed
-  context.log.verbose(`${logPrefix}|KEY=${insKey}|Inserting entity`);
-  const { e1: resultOrError, e2: sResponse } = await insertEntity({
-    PartitionKey: eg.String(insPartitionKey),
-    RowKey: eg.String(insKey),
-    version: eg.Int32(version)
-  });
-  if (resultOrError.isLeft() && sResponse.statusCode !== 409) {
-    // retry
-    context.log.error(`${logPrefix}|ERROR=${resultOrError.value.message}`);
-    throw resultOrError.value;
-  }
-
-  return true;
-}
-
 const activityFunction: AzureFunction = async (
   context: Context,
   rawInput: unknown
-): Promise<string> => {
-  const decodedInputOrError = Input.decode(rawInput);
-  if (decodedInputOrError.isLeft()) {
-    context.log.error(
-      `UpdateServiceSubscriptionFeedActivity|Cannot parse input|ERROR=${readableReport(
-        decodedInputOrError.value
-      )}`
-    );
-    return "FAILURE";
-  }
-
-  const decodedInput = decodedInputOrError.value;
-
-  const { fiscalCode, operation, updatedAt, version } = decodedInput;
-
-  // The date part of the key will be in UTC time zone, with format: YYYY-MM-DD
-  const utcTodayPrefix = new Date(updatedAt).toISOString().substring(0, 10);
-
-  // Create a SHA256 hash of the fiscal code
-  // see https://nodejs.org/api/crypto.html#crypto_crypto_createhash_algorithm_options
-  const fiscalCodeHash = crypto
-    .createHash("sha256")
-    .update(fiscalCode)
-    .digest("hex");
-
-  const logPrefix = `UpdateSubscriptionFeedActivity|PROFILE=${fiscalCode}|OPERATION=${operation}|PROFILE=${fiscalCode}`;
-
-  // Entity keys have the following format
-  //
-  // Profile subscription events: P-<DATE>-<EVENT>-<HASH>
-  // Service subscription events: S-<DATE>-<SERVICE_ID>-<EVENT>-<HASH>
-  //
-  // Where:
-  //
-  // * DATE is "YYYY-MM-DD" (UTC)
-  // * SERVICE_ID is the service ID that the user subscribed/unsubscribed
-  // * EVENT is either "S" for subscription events or "U" for unsubscriptions
-  // * HASH is the hex encoded SHA256 hash of the fiscal code
-  //
-  const sPartitionKey =
-    decodedInput.subscriptionKind === "PROFILE"
-      ? `P-${utcTodayPrefix}-S`
-      : `S-${utcTodayPrefix}-${decodedInput.serviceId}-S`;
-  const uPartitionKey =
-    decodedInput.subscriptionKind === "PROFILE"
-      ? `P-${utcTodayPrefix}-U`
-      : `S-${utcTodayPrefix}-${decodedInput.serviceId}-U`;
-
-  const sKey = `${sPartitionKey}-${fiscalCodeHash}`;
-  const uKey = `${uPartitionKey}-${fiscalCodeHash}`;
-
-  if (operation === "SUBSCRIBED") {
-    // we delete the entry from the unsubscriptions and we add it to the
-    // subscriptions
-    await updateSubscriptionStatus(
-      context,
-      logPrefix,
-      version,
-      uPartitionKey,
-      uKey,
-      sPartitionKey,
-      sKey
-    );
-  } else {
-    // we delete the entry from the subscriptions and we add it to the
-    // unsubscriptions
-    await updateSubscriptionStatus(
-      context,
-      logPrefix,
-      version,
-      sPartitionKey,
-      sKey,
-      uPartitionKey,
-      uKey
-    );
-  }
-
-  return "SUCCESS";
-};
-
+): Promise<string> =>
+  updateSubscriptionFeed(
+    context,
+    rawInput,
+    tableService,
+    config.SUBSCRIPTIONS_FEED_TABLE
+  );
 export default activityFunction;

--- a/UpsertServicePreferences/__tests__/handler.test.ts
+++ b/UpsertServicePreferences/__tests__/handler.test.ts
@@ -187,9 +187,9 @@ describe("UpsertServicePreferences", () => {
         some({ ...aRetrievedServicePreference, isInboxEnabled: false })
       )
     );
-    updateSubscriptionFeedMock.mockImplementationOnce(() => {
-      throw new Error("Subscription Feed Error");
-    });
+    updateSubscriptionFeedMock.mockImplementationOnce(() =>
+      Promise.reject(new Error("Subscription Feed Error"))
+    );
     const response = await upsertServicePreferencesHandler(
       context as any,
       aFiscalCode,

--- a/UpsertServicePreferences/__tests__/handler.test.ts
+++ b/UpsertServicePreferences/__tests__/handler.test.ts
@@ -1,11 +1,11 @@
 /* tslint:disable:no-any */
 import { none, some } from "fp-ts/lib/Option";
-import { taskEither } from "fp-ts/lib/TaskEither";
+import { fromLeft, taskEither } from "fp-ts/lib/TaskEither";
 import {
   aFiscalCode,
-  legacyProfileServicePreferencesSettings,
   aRetrievedProfileWithEmail,
-  autoProfileServicePreferencesSettings
+  autoProfileServicePreferencesSettings,
+  legacyProfileServicePreferencesSettings
 } from "../../__mocks__/mocks";
 import {
   aRetrievedService,
@@ -14,10 +14,25 @@ import {
   aServicePreference
 } from "../../__mocks__/mocks.service_preference";
 
-import { GetUpsertServicePreferencesHandler } from "../handler";
-import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
-import { left } from "fp-ts/lib/Either";
 import { CosmosErrors } from "@pagopa/io-functions-commons/dist/src/utils/cosmosdb_model";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { left } from "fp-ts/lib/Either";
+import { context } from "../../__mocks__/durable-functions";
+import * as subscriptionFeedHandler from "../../UpdateSubscriptionsFeedActivity/handler";
+import { GetUpsertServicePreferencesHandler } from "../handler";
+
+const updateSubscriptionFeedMock = jest
+  .fn()
+  .mockImplementation(() => Promise.resolve("SUCCESS"));
+jest
+  .spyOn(subscriptionFeedHandler, "updateSubscriptionFeed")
+  .mockImplementation(updateSubscriptionFeedMock);
+
+const telemetryClientMock = {
+  trackEvent: jest.fn()
+};
 
 const aRetrievedProfileInValidState = {
   ...aRetrievedProfileWithEmail,
@@ -30,12 +45,12 @@ const profileFindLastVersionByModelIdMock = jest.fn(() => {
 const serviceFindLastVersionByModelIdMock = jest.fn(_ => {
   return taskEither.of(some(aRetrievedService));
 });
-const serviceFindModelMock = jest.fn(_ => {
-  return taskEither.of(some(aRetrievedServicePreference));
-});
-const serviceUpsertModelMock = jest.fn(_ => {
-  return taskEither.of(_);
-});
+const servicePreferenceFindModelMock = jest
+  .fn()
+  .mockImplementation(_ => taskEither.of(some(aRetrievedServicePreference)));
+const servicePreferenceUpsertModelMock = jest
+  .fn()
+  .mockImplementation(_ => taskEither.of(_));
 
 const profileModelMock = {
   findLastVersionByModelId: profileFindLastVersionByModelIdMock
@@ -44,28 +59,35 @@ const serviceModelMock = {
   findLastVersionByModelId: serviceFindLastVersionByModelIdMock
 };
 const servicePreferenceModelMock = {
-  find: serviceFindModelMock,
-  upsert: serviceUpsertModelMock
+  find: servicePreferenceFindModelMock,
+  upsert: servicePreferenceUpsertModelMock
+};
+
+const aDisabledInboxServicePreference = {
+  ...aServicePreference,
+  is_inbox_enabled: false
 };
 
 const upsertServicePreferencesHandler = GetUpsertServicePreferencesHandler(
+  telemetryClientMock as any,
   profileModelMock as any,
   serviceModelMock as any,
-  servicePreferenceModelMock as any
+  servicePreferenceModelMock as any,
+  {} as any,
+  "SubFeedTableName" as NonEmptyString
 );
 
+// tslint:disable-next-line: no-big-function
 describe("UpsertServicePreferences", () => {
   beforeEach(() => jest.clearAllMocks());
 
   it("should return Success if user service preferences has been upserted", async () => {
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
     );
-
-    console.log(response);
 
     expect(response).toMatchObject({
       kind: "IResponseSuccessJson",
@@ -75,6 +97,162 @@ describe("UpsertServicePreferences", () => {
     expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalled();
     expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalled();
     expect(servicePreferenceModelMock.upsert).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.find).toHaveBeenCalled();
+  });
+
+  it("should return Success if user service preferences has been upserted without updatingSubscriptionFeed if isInboxEnabled has not been changed", async () => {
+    const response = await upsertServicePreferencesHandler(
+      context as any,
+      aFiscalCode,
+      aServiceId,
+      aServicePreference
+    );
+
+    expect(response).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: aServicePreference
+    });
+
+    expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.upsert).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.find).toHaveBeenCalled();
+    expect(updateSubscriptionFeedMock).not.toHaveBeenCalled();
+  });
+
+  it("should return Success if user service preferences has been upserted with subscriptionFeed UNSUBSCRIBED in case isInboxEnabled has been changed to false", async () => {
+    const response = await upsertServicePreferencesHandler(
+      context as any,
+      aFiscalCode,
+      aServiceId,
+      aDisabledInboxServicePreference
+    );
+
+    expect(response).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: aDisabledInboxServicePreference
+    });
+
+    expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.upsert).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.find).toHaveBeenCalled();
+    expect(updateSubscriptionFeedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operation: "UNSUBSCRIBED",
+        subscriptionKind: "SERVICE"
+      }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("should return Success if user service preferences has been upserted with subscriptionFeed SUBSCRIBED in case isInboxEnabled has been changed to true", async () => {
+    servicePreferenceFindModelMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({ ...aRetrievedServicePreference, isInboxEnabled: false })
+      )
+    );
+    const response = await upsertServicePreferencesHandler(
+      context as any,
+      aFiscalCode,
+      aServiceId,
+      aServicePreference
+    );
+
+    expect(response).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: aServicePreference
+    });
+
+    expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.upsert).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.find).toHaveBeenCalled();
+    expect(updateSubscriptionFeedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operation: "SUBSCRIBED",
+        subscriptionKind: "SERVICE"
+      }),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it("should return Success with upserted user service preferences even if subscription feed update throw an error", async () => {
+    servicePreferenceFindModelMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({ ...aRetrievedServicePreference, isInboxEnabled: false })
+      )
+    );
+    updateSubscriptionFeedMock.mockImplementationOnce(() => {
+      throw new Error("Subscription Feed Error");
+    });
+    const response = await upsertServicePreferencesHandler(
+      context as any,
+      aFiscalCode,
+      aServiceId,
+      aServicePreference
+    );
+
+    expect(response).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: aServicePreference
+    });
+
+    expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.upsert).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.find).toHaveBeenCalled();
+    expect(updateSubscriptionFeedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operation: "SUBSCRIBED",
+        subscriptionKind: "SERVICE"
+      }),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(telemetryClientMock.trackEvent).toHaveBeenCalled();
+  });
+
+  it("should return Success with upserted user service preferences even if subscription feed update returns FAILURE", async () => {
+    servicePreferenceFindModelMock.mockImplementationOnce(() =>
+      taskEither.of(
+        some({ ...aRetrievedServicePreference, isInboxEnabled: false })
+      )
+    );
+    updateSubscriptionFeedMock.mockImplementationOnce(() =>
+      Promise.resolve("FAILURE")
+    );
+    const response = await upsertServicePreferencesHandler(
+      context as any,
+      aFiscalCode,
+      aServiceId,
+      aServicePreference
+    );
+
+    expect(response).toMatchObject({
+      kind: "IResponseSuccessJson",
+      value: aServicePreference
+    });
+
+    expect(profileModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(serviceModelMock.findLastVersionByModelId).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.upsert).toHaveBeenCalled();
+    expect(servicePreferenceModelMock.find).toHaveBeenCalled();
+    expect(updateSubscriptionFeedMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        operation: "SUBSCRIBED",
+        subscriptionKind: "SERVICE"
+      }),
+      expect.anything(),
+      expect.anything()
+    );
+    expect(telemetryClientMock.trackEvent).toHaveBeenCalled();
   });
 
   // ---------------------------------------------
@@ -86,7 +264,7 @@ describe("UpsertServicePreferences", () => {
     });
 
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
@@ -107,7 +285,7 @@ describe("UpsertServicePreferences", () => {
     });
 
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
@@ -128,7 +306,7 @@ describe("UpsertServicePreferences", () => {
     });
 
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
@@ -147,7 +325,7 @@ describe("UpsertServicePreferences", () => {
     });
 
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
@@ -160,13 +338,32 @@ describe("UpsertServicePreferences", () => {
     expect(servicePreferenceModelMock.upsert).not.toHaveBeenCalled();
   });
 
-  it("should return IResponseErrorQuery if serviceSettings model raise an error", async () => {
-    serviceUpsertModelMock.mockImplementationOnce(() => {
+  it("should return IResponseErrorQuery if serviceSettings model find raise an error", async () => {
+    servicePreferenceFindModelMock.mockImplementationOnce(() => {
+      return fromLeft({} as CosmosErrors);
+    });
+
+    const response = await upsertServicePreferencesHandler(
+      context as any,
+      aFiscalCode,
+      aServiceId,
+      aServicePreference
+    );
+
+    expect(response).toMatchObject({
+      kind: "IResponseErrorQuery"
+    });
+
+    expect(servicePreferenceModelMock.upsert).not.toHaveBeenCalled();
+  });
+
+  it("should return IResponseErrorQuery if serviceSettings model upsert raise an error", async () => {
+    servicePreferenceUpsertModelMock.mockImplementationOnce(() => {
       return taskEither.fromEither(left({} as CosmosErrors));
     });
 
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
@@ -190,7 +387,7 @@ describe("UpsertServicePreferences", () => {
     });
 
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       aServicePreference
@@ -205,7 +402,7 @@ describe("UpsertServicePreferences", () => {
 
   it("should return IResponseErrorConflict if service preference han a different version from profile's one", async () => {
     const response = await upsertServicePreferencesHandler(
-      // (context as any) as Context,
+      context as any,
       aFiscalCode,
       aServiceId,
       {

--- a/UpsertServicePreferences/handler.ts
+++ b/UpsertServicePreferences/handler.ts
@@ -46,8 +46,30 @@ import {
   toUserServicePreferenceFromModel
 } from "../utils/service_preferences";
 
+import { Context } from "@azure/functions";
+import { ContextMiddleware } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 import { NonNegativeInteger } from "@pagopa/io-functions-commons/node_modules/@pagopa/ts-commons/lib/numbers";
+import { enumType } from "@pagopa/ts-commons/lib/types";
 import { identity } from "fp-ts/lib/function";
+import { Option } from "fp-ts/lib/Option";
+import * as t from "io-ts";
+import { updateSubscriptionFeedTask } from "./subscription_feed";
+
+import { initAppInsights } from "@pagopa/ts-commons/lib/appinsights";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { TableService } from "azure-storage";
+
+enum FeedOperationEnum {
+  "SUBSCRIBED" = "SUBSCRIBED",
+  "UNSUBSCRIBED" = "UNSUBSCRIBED",
+  "NO_UPDATE" = "NO_UPDATE"
+}
+
+export type FeedOperation = t.TypeOf<typeof FeedOperation>;
+export const FeedOperation = enumType<FeedOperationEnum>(
+  FeedOperationEnum,
+  "FeedOperation"
+);
 
 type IUpsertServicePreferencesHandlerResult =
   | IResponseSuccessJson<ServicePreference>
@@ -62,6 +84,7 @@ type IUpsertServicePreferencesHandlerResult =
  * a Not Found error.
  */
 type IUpsertServicePreferencesHandler = (
+  context: Context,
   fiscalCode: FiscalCode,
   serviceId: ServiceId,
   servicePreference: ServicePreference
@@ -150,15 +173,43 @@ const upsertUserServicePreferences = (
     )
     .map(toUserServicePreferenceFromModel);
 
+const decodeOperation = (isInboxEnabled: boolean) =>
+  isInboxEnabled
+    ? FeedOperationEnum.SUBSCRIBED
+    : FeedOperationEnum.UNSUBSCRIBED;
+
+/**
+ * Calculate Feed operation to perform by considering:
+ * - the previous service preference's inboxEnabled (if exists)
+ * - the current one that should be upserted.
+ * @param maybePreviousInboxEnabled The previous service preference's inboxEnabled property
+ * @param currentInboxEnabled The current service preference's inboxEnabled property
+ * @returns a FeedOperation to be performed. Possible values are SUBSCRIBED, UNSUBSCRIBED or NO_UPDATE
+ */
+const getFeedOperation = (
+  maybePreviousInboxEnabled: Option<boolean>,
+  currentInboxEnabled: boolean
+): FeedOperation =>
+  maybePreviousInboxEnabled.foldL(
+    () => decodeOperation(currentInboxEnabled),
+    prev =>
+      prev !== currentInboxEnabled
+        ? decodeOperation(currentInboxEnabled)
+        : FeedOperationEnum.NO_UPDATE
+  );
 /**
  * Return a type safe GetServicePreferences handler.
  */
 export const GetUpsertServicePreferencesHandler = (
+  telemetryClient: ReturnType<typeof initAppInsights>,
   profileModels: ProfileModel,
   serviceModels: ServiceModel,
-  servicePreferencesModel: ServicesPreferencesModel
+  servicePreferencesModel: ServicesPreferencesModel,
+  tableService: TableService,
+  subscriptionFeedTable: NonEmptyString,
+  logPrefix: string = "GetUpsertServicePreferencesHandler"
 ): IUpsertServicePreferencesHandler => {
-  return async (fiscalCode, serviceId, servicePreference) =>
+  return async (context, fiscalCode, serviceId, servicePreference) =>
     sequenceS(te.taskEither)({
       profile: getProfileOrErrorResponse(profileModels)(fiscalCode),
       service: getServiceOrErrorResponse(serviceModels)(serviceId)
@@ -190,7 +241,68 @@ export const GetUpsertServicePreferencesHandler = (
             version
           }))
       )
-      .chain(upsertUserServicePreferences(servicePreferencesModel))
+      .chain(results =>
+        servicePreferencesModel
+          .find([
+            makeServicesPreferencesDocumentId(
+              fiscalCode,
+              serviceId,
+              results.version
+            ),
+            fiscalCode
+          ])
+          .bimap(
+            failure =>
+              ResponseErrorQuery(
+                "Error while retrieving the user's service preferences",
+                failure
+              ),
+            maybeExistingServicesPreference => ({
+              ...results,
+              feedOperation: getFeedOperation(
+                maybeExistingServicesPreference.map(
+                  pref => pref.isInboxEnabled
+                ),
+                results.servicePreferencesToUpsert.is_inbox_enabled
+              )
+            })
+          )
+      )
+      .chain(results =>
+        upsertUserServicePreferences(servicePreferencesModel)(results).map(
+          upsertedUserServicePreference => ({
+            ...results,
+            updatedAt: new Date().getTime(),
+            upsertedUserServicePreference
+          })
+        )
+      )
+      .chain(
+        ({
+          feedOperation,
+          updatedAt,
+          version,
+          upsertedUserServicePreference
+        }) =>
+          feedOperation !== FeedOperationEnum.NO_UPDATE
+            ? updateSubscriptionFeedTask(
+                tableService,
+                subscriptionFeedTable,
+                telemetryClient,
+                context,
+                {
+                  fiscalCode,
+                  operation: feedOperation,
+                  serviceId,
+                  subscriptionKind: "SERVICE",
+                  updatedAt,
+                  version
+                },
+                logPrefix
+              ).map(() => upsertedUserServicePreference)
+            : te.taskEither.of(upsertedUserServicePreference)
+      )
+
       .fold<IUpsertServicePreferencesHandlerResult>(
         identity,
         ResponseSuccessJson
@@ -202,18 +314,24 @@ export const GetUpsertServicePreferencesHandler = (
  * Wraps a UpsertServicePreferences handler inside an Express request handler.
  */
 export function UpsertServicePreferences(
+  telemetryClient: ReturnType<typeof initAppInsights>,
   profileModels: ProfileModel,
   serviceModels: ServiceModel,
-  servicePreferencesModel: ServicesPreferencesModel
+  servicePreferencesModel: ServicesPreferencesModel,
+  tableService: TableService,
+  subscriptionFeedTable: NonEmptyString
 ): express.RequestHandler {
   const handler = GetUpsertServicePreferencesHandler(
+    telemetryClient,
     profileModels,
     serviceModels,
-    servicePreferencesModel
+    servicePreferencesModel,
+    tableService,
+    subscriptionFeedTable
   );
 
   const middlewaresWrap = withRequestMiddlewares(
-    // ContextMiddleware(),
+    ContextMiddleware(),
     FiscalCodeMiddleware,
     RequiredParamMiddleware("serviceId", ServiceId),
     RequiredBodyPayloadMiddleware(ServicePreference)

--- a/UpsertServicePreferences/handler.ts
+++ b/UpsertServicePreferences/handler.ts
@@ -206,7 +206,7 @@ export const GetUpsertServicePreferencesHandler = (
   serviceModels: ServiceModel,
   servicePreferencesModel: ServicesPreferencesModel,
   tableService: TableService,
-  subscriptionFeedTable: NonEmptyString,
+  subscriptionFeedTableName: NonEmptyString,
   logPrefix: string = "GetUpsertServicePreferencesHandler"
 ): IUpsertServicePreferencesHandler => {
   return async (context, fiscalCode, serviceId, servicePreference) =>
@@ -287,7 +287,7 @@ export const GetUpsertServicePreferencesHandler = (
           feedOperation !== FeedOperationEnum.NO_UPDATE
             ? updateSubscriptionFeedTask(
                 tableService,
-                subscriptionFeedTable,
+                subscriptionFeedTableName,
                 telemetryClient,
                 context,
                 {
@@ -319,7 +319,7 @@ export function UpsertServicePreferences(
   serviceModels: ServiceModel,
   servicePreferencesModel: ServicesPreferencesModel,
   tableService: TableService,
-  subscriptionFeedTable: NonEmptyString
+  subscriptionFeedTableName: NonEmptyString
 ): express.RequestHandler {
   const handler = GetUpsertServicePreferencesHandler(
     telemetryClient,
@@ -327,7 +327,7 @@ export function UpsertServicePreferences(
     serviceModels,
     servicePreferencesModel,
     tableService,
-    subscriptionFeedTable
+    subscriptionFeedTableName
   );
 
   const middlewaresWrap = withRequestMiddlewares(

--- a/UpsertServicePreferences/subscription_feed.ts
+++ b/UpsertServicePreferences/subscription_feed.ts
@@ -1,0 +1,102 @@
+import { Context } from "@azure/functions";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { IResponseErrorQuery } from "@pagopa/io-functions-commons/dist/src/utils/response";
+import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { TelemetryClient } from "applicationinsights";
+import { EventTelemetry } from "applicationinsights/out/Declarations/Contracts";
+import { TableService } from "azure-storage";
+import { toError, tryCatch2v } from "fp-ts/lib/Either";
+import {
+  fromEither,
+  taskEither,
+  TaskEither,
+  tryCatch
+} from "fp-ts/lib/TaskEither";
+import * as t from "io-ts";
+import { updateSubscriptionFeed } from "../UpdateSubscriptionsFeedActivity/handler";
+
+export const UpdateSubscriptionFeedInput = t.interface({
+  fiscalCode: FiscalCode,
+  operation: t.union([t.literal("SUBSCRIBED"), t.literal("UNSUBSCRIBED")]),
+  serviceId: ServiceId,
+  subscriptionKind: t.literal("SERVICE"),
+  updatedAt: t.number,
+  version: NonNegativeInteger
+});
+
+export type UpdateSubscriptionFeedInput = t.TypeOf<
+  typeof UpdateSubscriptionFeedInput
+>;
+
+export const trackSubscriptionFeedFailure = (
+  context: Context,
+  aiClient: TelemetryClient,
+  input: UpdateSubscriptionFeedInput,
+  kind: "EXCEPTION" | "FAILURE",
+  logPrefix: string,
+  message: string
+) => {
+  context.log.verbose(
+    `${logPrefix}| Error while trying to update subscriptionFeed|ERROR=${message}`
+  );
+  aiClient.trackEvent({
+    name: "subscriptionFeed.upsertServicesPreferences.failure",
+    properties: {
+      ...input,
+      kind,
+      updatedAt: input.updatedAt.toString(),
+      version: input.version.toString()
+    },
+    tagOverrides: { samplingEnabled: "false" }
+  } as EventTelemetry);
+};
+
+export const updateSubscriptionFeedTask = (
+  tableService: TableService,
+  subscriptionFeedTable: NonEmptyString,
+  aiClient: TelemetryClient,
+  context: Context,
+  input: UpdateSubscriptionFeedInput,
+  logPrefix: string
+): TaskEither<IResponseErrorQuery, boolean> =>
+  fromEither(
+    tryCatch2v(
+      () =>
+        updateSubscriptionFeed(
+          context,
+          input,
+          tableService,
+          subscriptionFeedTable
+        ),
+      toError
+    )
+  )
+    .chain(result => tryCatch(() => result, toError))
+    .foldTaskEither(
+      err => {
+        trackSubscriptionFeedFailure(
+          context,
+          aiClient,
+          input,
+          "EXCEPTION",
+          logPrefix,
+          err.message
+        );
+        return taskEither.of(false);
+      },
+      result => {
+        const isSuccess = result === "SUCCESS";
+        if (!isSuccess) {
+          trackSubscriptionFeedFailure(
+            context,
+            aiClient,
+            input,
+            "FAILURE",
+            logPrefix,
+            "FAILURE"
+          );
+        }
+        return taskEither.of(isSuccess);
+      }
+    );

--- a/UpsertServicePreferences/subscription_feed.ts
+++ b/UpsertServicePreferences/subscription_feed.ts
@@ -6,13 +6,8 @@ import { FiscalCode, NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { TelemetryClient } from "applicationinsights";
 import { EventTelemetry } from "applicationinsights/out/Declarations/Contracts";
 import { TableService } from "azure-storage";
-import { toError, tryCatch2v } from "fp-ts/lib/Either";
-import {
-  fromEither,
-  taskEither,
-  TaskEither,
-  tryCatch
-} from "fp-ts/lib/TaskEither";
+import { toError } from "fp-ts/lib/Either";
+import { taskEither, TaskEither, tryCatch } from "fp-ts/lib/TaskEither";
 import * as t from "io-ts";
 import { updateSubscriptionFeed } from "../UpdateSubscriptionsFeedActivity/handler";
 

--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -15,7 +15,7 @@ import {
   OrchestratorInput as EmailValidationProcessOrchestratorInput,
   OrchestratorResult as EmailValidationProcessOrchestratorResult
 } from "../EmailValidationProcessOrchestrator/handler";
-import { Input as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/index";
+import { Input as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/handler";
 import { diffBlockedServices } from "../utils/profiles";
 
 import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@pagopa/io-functions-commons": "^20.6.6",
     "@pagopa/ts-commons": "^9.6.0",
     "abort-controller": "^3.0.0",
-    "applicationinsights": "^1.7.4",
+    "applicationinsights": "^1.8.10",
     "azure-storage": "^2.10.3",
     "date-fns": "^2.16.1",
     "dependency-check": "^4.1.0",

--- a/utils/subscription_feed.ts
+++ b/utils/subscription_feed.ts
@@ -1,0 +1,81 @@
+import { Context } from "@azure/functions";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { TableService, TableUtilities } from "azure-storage";
+import { isNone } from "fp-ts/lib/Option";
+import { deleteTableEntity, insertTableEntity } from "./storage";
+
+const eg = TableUtilities.entityGenerator;
+
+/**
+ * Updates the subscrption status of a user.
+ *
+ * User subscribed or unsubscribed events are stored as empty entities in an
+ * Azure storage table.
+ *
+ * The entity key is composed by the day of the event, the service ID (if it's
+ * a service subscription event), a character that indicates whether it's a
+ * subscribed (S) or unsubscribed (U) event and the SHA256 hash of the fiscal
+ * code of the user.
+ *
+ * For each day, (optionally) service and user, either the S or the U key exist,
+ * but not both (it would not make sense).
+ *
+ * When the key does not include a service ID, it refers to a profile
+ * subscription event, meaning the user registered to IO (subscribed) or deleted
+ * her account (unsubscribed).
+ * When the key includes the service ID, it refers to a service subscription
+ * event, meaning the user activated (subscribed) or deactivated (unsubscribed)
+ * a specific service.
+ */
+export const updateSubscriptionStatus = (
+  tableService: TableService,
+  tableName: NonEmptyString
+) => async (
+  context: Context,
+  logPrefix: string,
+  version: number,
+  delPartitionKey: string,
+  delKey: string,
+  insPartitionKey: string,
+  insKey: string
+): Promise<true> => {
+  const insertEntity = insertTableEntity(tableService, tableName);
+  const deleteEntity = deleteTableEntity(tableService, tableName);
+  // First we try to delete a previous (un)subscriptions operation
+  // from the subscription feed entries for the current day
+  context.log.verbose(`${logPrefix}|KEY=${delKey}|Deleting entity`);
+  const { e1: maybeError, e2: uResponse } = await deleteEntity({
+    PartitionKey: eg.String(delPartitionKey),
+    RowKey: eg.String(delKey)
+  });
+
+  // If deleteEntity is successful it means the user
+  // previously made an opposite choice (in the same day).
+  // Since we're going to expose only the delta for this day,
+  // and we've just deleted the opposite operation, we go on here.
+  if (isNone(maybeError)) {
+    return true;
+  }
+
+  if (maybeError.isSome() && uResponse.statusCode !== 404) {
+    // retry
+    context.log.error(`${logPrefix}|ERROR=${maybeError.value.message}`);
+    throw maybeError.value;
+  }
+
+  // If deleteEntity has not found any entry,
+  // we insert the new (un)subscription entry into the feed
+  context.log.verbose(`${logPrefix}|KEY=${insKey}|Inserting entity`);
+  const { e1: resultOrError, e2: sResponse } = await insertEntity({
+    PartitionKey: eg.String(insPartitionKey),
+    RowKey: eg.String(insKey),
+    version: eg.Int32(version)
+  });
+  if (resultOrError.isLeft() && sResponse.statusCode !== 409) {
+    // retry
+    context.log.error(`${logPrefix}|ERROR=${resultOrError.value.message}`);
+    throw resultOrError.value;
+  }
+
+  return true;
+};


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
In order to complete the opt-in/opt-out service model implemetation, this PR adds subscription feed update while servicePreferences get upserted.
#### List of Changes
<!--- Describe your changes in detail -->
- `UpdateSubscriptionFeedActivity` refactor, in order to be called either from `UpsertedProfileOrchestrator` and `UpsertServicePreferences`
- Update `UpsertServicePreferences`'s handler
- `subscription_feed` utility methods moved apart from handlers functions

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Every change made to servicePreference must be registered in subscriptionFeed in order to be consistent while sending notification to users.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
