### PR TITLE
switch fiscalCode with spidRequestId in StoreSpidLogs

### DIFF
--- a/StoreSpidLogs/function.json
+++ b/StoreSpidLogs/function.json
@@ -10,7 +10,7 @@
     {
       "type": "blob",
       "name": "spidRequestResponse",
-      "path": "spidassertions/{spidRequestId}-{createdAtDay}-{fiscalCode}.json",
+      "path": "spidassertions/{fiscalCode}-{createdAtDay}-{spidRequestId}.json",
       "connection": "LogsStorageConnection",
       "direction": "out"
     }


### PR DESCRIPTION
Azure Storage allows to use a prefix for a faster indexed search, instead of a full scan.

I'm not sure why the current filename layout was picked though.