### PR TITLE
[#IP-368] table service unhandled exception

### DIFF
--- a/utils/__tests__/storage.test.ts
+++ b/utils/__tests__/storage.test.ts
@@ -1,0 +1,76 @@
+import { ServiceResponse, TableService } from "azure-storage";
+import { left, right } from "fp-ts/lib/Either";
+import { none, some } from "fp-ts/lib/Option";
+import { deleteTableEntity, insertTableEntity } from "../storage";
+
+const mockInsertEntity = jest.fn();
+const mockDeleteEntity = jest.fn();
+const mockTableService = ({
+  deleteEntity: mockDeleteEntity,
+  insertEntity: mockInsertEntity
+} as unknown) as TableService;
+
+const genericError = new Error("Generic Error");
+const aTableName = "table";
+const anEntityDescriptor = {
+  prop: "value"
+};
+const anErrorResponse: ServiceResponse = {
+  isSuccessful: false,
+  md5: "md5",
+  statusCode: 404
+};
+const aSuccessResponse: ServiceResponse = {
+  body: JSON.stringify(anEntityDescriptor),
+  isSuccessful: true,
+  md5: "md5",
+  statusCode: 200
+};
+
+describe("insertTableEntity", () => {
+  it.each`
+    title                                                      | error           | result                | response            | e1                           | e2
+    ${"returns an error if insertEntity fail"}                 | ${genericError} | ${null}               | ${null}             | ${left(genericError)}        | ${null}
+    ${"returns an error if insertEntity fail with a response"} | ${genericError} | ${null}               | ${anErrorResponse}  | ${left(genericError)}        | ${anErrorResponse}
+    ${"returns the response value if insertEntity succeded"}   | ${null}         | ${anEntityDescriptor} | ${aSuccessResponse} | ${right(anEntityDescriptor)} | ${aSuccessResponse}
+  `("should $title", async ({ error, result, response, e1, e2 }) => {
+    mockInsertEntity.mockImplementationOnce((_, __, callback) =>
+      callback(error, result, response)
+    );
+    const insertResponse = await insertTableEntity(
+      mockTableService,
+      aTableName
+    )(anEntityDescriptor);
+    expect(mockInsertEntity).toBeCalledWith(
+      aTableName,
+      anEntityDescriptor,
+      expect.any(Function)
+    );
+    expect(insertResponse.e1).toEqual(e1);
+    expect(insertResponse.e2).toEqual(e2);
+  });
+});
+
+describe("deleteTableEntity", () => {
+  it.each`
+    title                                                      | error           | response            | e1                    | e2
+    ${"returns an error if deleteEntity fail"}                 | ${genericError} | ${null}             | ${some(genericError)} | ${null}
+    ${"returns an error if deleteEntity fail with a response"} | ${genericError} | ${anErrorResponse}  | ${some(genericError)} | ${anErrorResponse}
+    ${"returns the response value if deleteEntity succeded"}   | ${null}         | ${aSuccessResponse} | ${none}               | ${aSuccessResponse}
+  `("should $title", async ({ error, response, e1, e2 }) => {
+    mockDeleteEntity.mockImplementationOnce((_, __, callback) =>
+      callback(error, response)
+    );
+    const deleteResponse = await deleteTableEntity(
+      mockTableService,
+      aTableName
+    )(anEntityDescriptor);
+    expect(mockDeleteEntity).toBeCalledWith(
+      aTableName,
+      anEntityDescriptor,
+      expect.any(Function)
+    );
+    expect(deleteResponse.e1).toEqual(e1);
+    expect(deleteResponse.e2).toEqual(e2);
+  });
+});

--- a/utils/__tests__/storage.test.ts
+++ b/utils/__tests__/storage.test.ts
@@ -32,6 +32,7 @@ describe("insertTableEntity", () => {
     title                                                      | error           | result                | response            | e1                           | e2
     ${"returns an error if insertEntity fail"}                 | ${genericError} | ${null}               | ${null}             | ${left(genericError)}        | ${null}
     ${"returns an error if insertEntity fail with a response"} | ${genericError} | ${null}               | ${anErrorResponse}  | ${left(genericError)}        | ${anErrorResponse}
+    ${"returns an error if insertEntity fail with no error"}   | ${null}         | ${null}               | ${anErrorResponse}  | ${left(expect.any(Error))}   | ${anErrorResponse}
     ${"returns the response value if insertEntity succeded"}   | ${null}         | ${anEntityDescriptor} | ${aSuccessResponse} | ${right(anEntityDescriptor)} | ${aSuccessResponse}
   `("should $title", async ({ error, result, response, e1, e2 }) => {
     mockInsertEntity.mockImplementationOnce((_, __, callback) =>
@@ -53,10 +54,11 @@ describe("insertTableEntity", () => {
 
 describe("deleteTableEntity", () => {
   it.each`
-    title                                                      | error           | response            | e1                    | e2
-    ${"returns an error if deleteEntity fail"}                 | ${genericError} | ${null}             | ${some(genericError)} | ${null}
-    ${"returns an error if deleteEntity fail with a response"} | ${genericError} | ${anErrorResponse}  | ${some(genericError)} | ${anErrorResponse}
-    ${"returns the response value if deleteEntity succeded"}   | ${null}         | ${aSuccessResponse} | ${none}               | ${aSuccessResponse}
+    title                                                      | error           | response            | e1                         | e2
+    ${"returns an error if deleteEntity fail"}                 | ${genericError} | ${null}             | ${some(genericError)}      | ${null}
+    ${"returns an error if deleteEntity fail with a response"} | ${genericError} | ${anErrorResponse}  | ${some(genericError)}      | ${anErrorResponse}
+    ${"returns an error if deleteEntity fail with no error"}   | ${null}         | ${anErrorResponse}  | ${some(expect.any(Error))} | ${anErrorResponse}
+    ${"returns the response value if deleteEntity succeded"}   | ${null}         | ${aSuccessResponse} | ${none}                    | ${aSuccessResponse}
   `("should $title", async ({ error, response, e1, e2 }) => {
     mockDeleteEntity.mockImplementationOnce((_, __, callback) =>
       callback(error, response)

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -26,7 +26,7 @@ export const insertTableEntity = (
         response: ServiceResponse
       ) =>
         resolve(
-          // We need to check error first becouse response could be null
+          // We need to check error first because response could be null
           // @ref https://github.com/Azure/azure-storage-node/blob/v2.10.2/lib/common/services/storageserviceclient.js#L250
           error || !response.isSuccessful
             ? Tuple2(left(error), response)
@@ -51,7 +51,7 @@ export const deleteTableEntity = (
       entityDescriptor,
       (error: Error, response: ServiceResponse) =>
         resolve(
-          // We need to check error first becouse response could be null
+          // We need to check error first because response could be null
           // @ref https://github.com/Azure/azure-storage-node/blob/v2.10.2/lib/common/services/storageserviceclient.js#L250
           error || !response.isSuccessful
             ? Tuple2(some(error), response)

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -26,9 +26,11 @@ export const insertTableEntity = (
         response: ServiceResponse
       ) =>
         resolve(
-          response.isSuccessful
-            ? Tuple2(right(result), response)
-            : Tuple2(left(error), response)
+          // We need to check error first becouse response could be null
+          // @ref https://github.com/Azure/azure-storage-node/blob/v2.10.2/lib/common/services/storageserviceclient.js#L250
+          error || !response.isSuccessful
+            ? Tuple2(left(error), response)
+            : Tuple2(right(result), response)
         )
     )
   );
@@ -49,9 +51,11 @@ export const deleteTableEntity = (
       entityDescriptor,
       (error: Error, response: ServiceResponse) =>
         resolve(
-          response.isSuccessful
-            ? Tuple2(none, response)
-            : Tuple2(some(error), response)
+          // We need to check error first becouse response could be null
+          // @ref https://github.com/Azure/azure-storage-node/blob/v2.10.2/lib/common/services/storageserviceclient.js#L250
+          error || !response.isSuccessful
+            ? Tuple2(some(error), response)
+            : Tuple2(none, response)
         )
     )
   );

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -14,22 +14,28 @@ export const insertTableEntity = (
 ) => <T>(
   entityDescriptor: T
 ): Promise<
-  ITuple2<Either<Error, T | TableService.EntityMetadata>, ServiceResponse>
+  ITuple2<
+    Either<Error, T | TableService.EntityMetadata>,
+    ServiceResponse | null
+  >
 > => {
   return new Promise(resolve =>
     tableService.insertEntity(
       table,
       entityDescriptor,
       (
-        error: Error,
+        error: Error | null,
         result: T | TableService.EntityMetadata,
-        response: ServiceResponse
+        response: ServiceResponse | null
       ) =>
         resolve(
           // We need to check error first because response could be null
           // @ref https://github.com/Azure/azure-storage-node/blob/v2.10.2/lib/common/services/storageserviceclient.js#L250
           error || !response.isSuccessful
-            ? Tuple2(left(error), response)
+            ? Tuple2(
+                left(error || new Error("Unsuccessful response from storage")),
+                response
+              )
             : Tuple2(right(result), response)
         )
     )
@@ -44,17 +50,20 @@ export const deleteTableEntity = (
   table: string
 ) => <T>(
   entityDescriptor: T
-): Promise<ITuple2<Option<Error>, ServiceResponse>> => {
+): Promise<ITuple2<Option<Error>, ServiceResponse | null>> => {
   return new Promise(resolve =>
     tableService.deleteEntity(
       table,
       entityDescriptor,
-      (error: Error, response: ServiceResponse) =>
+      (error: Error | null, response: ServiceResponse | null) =>
         resolve(
           // We need to check error first because response could be null
           // @ref https://github.com/Azure/azure-storage-node/blob/v2.10.2/lib/common/services/storageserviceclient.js#L250
           error || !response.isSuccessful
-            ? Tuple2(some(error), response)
+            ? Tuple2(
+                some(error || new Error("Unsuccessful response from storage")),
+                response
+              )
             : Tuple2(none, response)
         )
     )

--- a/utils/subscription_feed.ts
+++ b/utils/subscription_feed.ts
@@ -90,7 +90,9 @@ export const updateSubscriptionStatus = (
 
   if (
     deleteResults.some(
-      _ => _.maybeError.isSome() && _.uResponse.statusCode !== 404
+      _ =>
+        // _.uResponse could be null
+        _.maybeError.isSome() && _.uResponse && _.uResponse.statusCode !== 404
     )
   ) {
     // retry
@@ -115,7 +117,8 @@ export const updateSubscriptionStatus = (
     RowKey: eg.String(insertEntity.rowKey),
     version: eg.Int32(version)
   });
-  if (resultOrError.isLeft() && sResponse.statusCode !== 409) {
+  // sResponse could be null
+  if (resultOrError.isLeft() && sResponse && sResponse.statusCode !== 409) {
     // retry
     context.log.error(`${logPrefix}|ERROR=${resultOrError.value.message}`);
     throw resultOrError.value;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* check `response.isSuccessful` only when Error falsy

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
On some scenarios the Azure table service returns an Error and a `null` response to the callbacks of `insertEntity` and `deleteEntity`. When this happens our code throw an unhandled exception trying to access to `response.isSuccessful`.

Application insights logs show the following error:

```
Exception while executing function: Functions.GetMessage node exited with code 1
   'Ingestion endpoint could not be reached. This batch of telemetry items has been lost. Use Disk Retry Caching to enable resending of failed telemetry. Error:',,  Error: getaddrinfo ENOTFOUND dc.services.visualstudio.com,LanguageWorkerConsoleLog[error]
Worker 00e991ee-XXXX-XXXX-XXXX-e2683f821aff uncaught exception (learn more: https://go.microsoft.com/fwlink/?linkid=2097909 ):
TypeError: Cannot read property 'isSuccessful' of null     at D:\home\site\wwwroot\dist\utils\storage.js:20:124 
at finalCallback (D:\home\site\wwwroot\node_modules\azure-storage\lib\services\table\tableservice.js:1323:9)
at D:\home\site\wwwroot\node_modules\azure-storage\lib\common\services\storageserviceclient.js:1016:11 
at processResponseCallback (D:\home\site\wwwroot\node_modules\azure-storage\lib\services\table\tableservice.js:1336:5)     at Request.processResponseCallback [as _callback]
(D:\home\site\wwwroot\node_modules\azure-storage\lib\common\services\storageserviceclient.js:329:13)
at self.callback (D:\home\site\wwwroot\node_modules\request\request.js:185:22)
at Request.emit (events.js:315:20)     at Request.onRequestError (D:\home\site\wwwroot\node_modules\request\request.js:877:8)
at ClientRequest.clsBind (D:\home\site\wwwroot\node_modules\cls-hooked\context.js:172:17)
at ClientRequest.emit (events.js:327:22)
```
The same error could occurs on `functions-admin`, `functions-cgn`, `functions-services`.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
