### PR TITLE
[#IP-410] Dismiss `UpsertedProfileOrchestratorV2` step 1: duplication

### DIFF
--- a/CreateProfile/__tests__/handler.test.ts
+++ b/CreateProfile/__tests__/handler.test.ts
@@ -18,7 +18,7 @@ import {
   aNewProfile,
   aRetrievedProfile
 } from "../../__mocks__/mocks";
-import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../../UpsertedProfileOrchestratorV2/handler";
+import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../../UpsertedProfileOrchestrator/handler";
 import { CreateProfileHandler } from "../handler";
 
 // eslint-disable-next-line functional/no-let
@@ -179,7 +179,7 @@ describe("CreateProfileHandler", () => {
 
     const dfClient = df.getClient(contextMock);
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "UpsertedProfileOrchestratorV2",
+      "UpsertedProfileOrchestrator",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/CreateProfile/handler.ts
+++ b/CreateProfile/handler.ts
@@ -35,7 +35,7 @@ import {
 import { isBefore } from "date-fns";
 import { pipe } from "fp-ts/lib/function";
 import { fromEither } from "fp-ts/lib/TaskEither";
-import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../UpsertedProfileOrchestratorV2/handler";
+import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../UpsertedProfileOrchestrator/handler";
 import { NewProfileMiddleware } from "../utils/middlewares/profile";
 import { retrievedProfileToExtendedProfile } from "../utils/profiles";
 
@@ -109,7 +109,7 @@ export function CreateProfileHandler(
 
     const dfClient = df.getClient(context);
     await dfClient.startNew(
-      "UpsertedProfileOrchestratorV2",
+      "UpsertedProfileOrchestrator",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/UpdateProfile/__tests__/handler.test.ts
+++ b/UpdateProfile/__tests__/handler.test.ts
@@ -23,7 +23,7 @@ import {
   manualApiProfileServicePreferencesSettings,
   manualProfileServicePreferencesSettings
 } from "../../__mocks__/mocks";
-import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../../UpsertedProfileOrchestratorV2/handler";
+import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../../UpsertedProfileOrchestrator/handler";
 import { UpdateProfileHandler } from "../handler";
 
 import { createTracker } from "../../__mocks__/tracking";
@@ -673,7 +673,7 @@ describe("UpdateProfileHandler", () => {
 
     const dfClient = df.getClient(contextMock);
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "UpsertedProfileOrchestratorV2",
+      "UpsertedProfileOrchestrator",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/UpdateProfile/handler.ts
+++ b/UpdateProfile/handler.ts
@@ -40,7 +40,7 @@ import {
 import { QueueClient, QueueSendMessageResponse } from "@azure/storage-queue";
 import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { MigrateServicesPreferencesQueueMessage } from "../MigrateServicePreferenceFromLegacy/handler";
-import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../UpsertedProfileOrchestratorV2/handler";
+import { OrchestratorInput as UpsertedProfileOrchestratorInput } from "../UpsertedProfileOrchestrator/handler";
 import { ProfileMiddleware } from "../utils/middlewares/profile";
 import {
   apiProfileToProfile,
@@ -244,10 +244,10 @@ export function UpdateProfileHandler(
         updatedAt: new Date()
       }
     );
-    // TODO: To enable the new orchestration change to UpsertedProfileOrchestratorV2
+    // TODO: To enable the new orchestration change to UpsertedProfileOrchestrator
     // Change the orchestrator after that in production the code is available to enable rollback
     await dfClient.startNew(
-      "UpsertedProfileOrchestratorV2",
+      "UpsertedProfileOrchestrator",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/UpsertedProfileOrchestrator/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestrator/__tests__/handler.test.ts
@@ -1,0 +1,1062 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import * as df from "durable-functions";
+import { Task } from "durable-functions/lib/src/classes";
+import { fromArray } from "fp-ts/lib/NonEmptyArray";
+import { context as contextMock } from "../../__mocks__/durable-functions";
+import {
+  aEmailChanged,
+  aFiscalCode,
+  aRetrievedProfile,
+  autoProfileServicePreferencesSettings,
+  manualProfileServicePreferencesSettings
+} from "../../__mocks__/mocks";
+import {
+  OrchestratorInput as EmailValidationProcessOrchestratorInput,
+  OrchestratorResult as EmailValidationProcessOrchestratorResult
+} from "../../EmailValidationProcessOrchestrator/handler";
+import {
+  getUpsertedProfileOrchestratorHandler,
+  OrchestratorInput as UpsertedProfileOrchestratorInput
+} from "../handler";
+
+import { BlockedInboxOrChannelEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/BlockedInboxOrChannel";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+import { consumeGenerator } from "../../utils/durable";
+
+import * as O from "fp-ts/lib/Option";
+import * as E from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
+
+const someRetryOptions = new df.RetryOptions(5000, 10);
+// eslint-disable-next-line functional/immutable-data
+someRetryOptions.backoffCoefficient = 1.5;
+
+// eslint-disable-next-line sonar/sonar-max-lines-per-function
+describe("UpsertedProfileOrchestrator", () => {
+  it("should not start the EmailValidationProcessOrchestrator if the email is not changed", () => {
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: { ...aRetrievedProfile, isWebhookEnabled: true },
+        oldProfile: aRetrievedProfile,
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callSubOrchestratorWithRetry: jest.fn(() => undefined),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      sendCashbackMessage: false
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).not.toBeCalled();
+  });
+
+  it("should start the activities with the right inputs", async () => {
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true // Enable inbox to start the SendWelcomeMessagesActivity
+        },
+        oldProfile: aRetrievedProfile,
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+  });
+
+  it("should enqueue a message if the notifyOn queue name is provided when an inbox become enabled", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true // Enable inbox to start the SendWelcomeMessagesActivity
+        },
+        oldProfile: aRetrievedProfile,
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should not call UpdateSubscriptionFeedActivity if oldProfile and newProfile have the same servicePreferenceMode", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toHaveBeenCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {}
+    );
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should not call UpdateSubscriptionFeedActivity switching from LEGACY to AUTO", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile
+        },
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(
+        fromArray([expectedQueueName]),
+        O.getOrElse(() => undefined)
+      ),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).not.toHaveBeenCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {}
+    );
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from LEGACY to MANUAL", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: manualProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile
+        },
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity to unsubscribe the entire profile switching from AUTO to MANUAL", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: manualProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult) // WELCOME
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult) // HOW TO
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult) // CASHBACK
+          .mockImplementationOnce(() => ({
+            kind: "SUCCESS",
+            preferences: []
+          })),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(
+      contextMockWithDf.df.callSubOrchestratorWithRetry
+    ).toHaveBeenCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    let nth = 1;
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "GetServicesPreferencesActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        settingsVersion:
+          upsertedProfileOrchestratorInput.oldProfile.servicePreferencesSettings
+            .version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        previousPreferences: [],
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      6,
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity to subscribe the entire profile switching from MANUAL to AUTO", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true, // Enable inbox to start the SendWelcomeMessagesActivity
+          servicePreferencesSettings: autoProfileServicePreferencesSettings
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          servicePreferencesSettings: manualProfileServicePreferencesSettings
+        },
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult) // WELCOME
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult) // HOW TO
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult) // CASHBACK
+          .mockReturnValueOnce({
+            kind: "SUCCESS",
+            preferences: []
+          }),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    let nth = 1;
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "GetServicesPreferencesActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        settingsVersion:
+          upsertedProfileOrchestratorInput.oldProfile.servicePreferencesSettings
+            .version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "SUBSCRIBED",
+        subscriptionKind: "PROFILE",
+        previousPreferences: [],
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toHaveBeenNthCalledWith(
+      nth++,
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+
+  it("should call UpdateSubscriptionFeedActivity with the difference between blockedInboxOrchannels when servicePreferenceMode is LEGACY", async () => {
+    const expectedQueueName = "queue_name" as NonEmptyString;
+    const upsertedProfileOrchestratorInput = pipe(
+      UpsertedProfileOrchestratorInput.decode({
+        newProfile: {
+          ...aRetrievedProfile,
+          blockedInboxOrChannels: {
+            service1: [BlockedInboxOrChannelEnum.INBOX],
+            service2: [BlockedInboxOrChannelEnum.INBOX]
+          },
+          email: aEmailChanged, // Email changed to start the EmailValidationProcessOrchestrator
+          isInboxEnabled: true // Enable inbox to start the SendWelcomeMessagesActivity
+        },
+        oldProfile: {
+          ...aRetrievedProfile,
+          blockedInboxOrChannels: {
+            service3: [BlockedInboxOrChannelEnum.INBOX]
+          }
+        },
+        updatedAt: new Date()
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode UpsertedProfileOrchestratorInput: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const emailValidationProcessOrchestratorResult = pipe(
+      EmailValidationProcessOrchestratorResult.decode({
+        kind: "SUCCESS"
+      }),
+      E.getOrElseW(errs =>
+        fail(
+          `Cannot decode EmailValidationProcessOrchestratorResult: ${readableReport(
+            errs
+          )}`
+        )
+      )
+    );
+
+    const sendWelcomeMessagesActivityResult = "SUCCESS";
+
+    const contextMockWithDf = {
+      ...contextMock,
+      df: {
+        Task: {
+          all: (tasks: readonly Task[]) => tasks
+        },
+        callActivityWithRetry: jest
+          .fn()
+          .mockReturnValueOnce(sendWelcomeMessagesActivityResult),
+        callSubOrchestratorWithRetry: jest.fn(
+          () => emailValidationProcessOrchestratorResult
+        ),
+        getInput: jest.fn(() => upsertedProfileOrchestratorInput)
+      }
+    };
+
+    const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
+      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
+      sendCashbackMessage: true
+    })(contextMockWithDf as any);
+
+    consumeGenerator(orchestratorHandler);
+
+    expect(contextMockWithDf.df.callSubOrchestratorWithRetry).toBeCalledWith(
+      "EmailValidationProcessOrchestrator",
+      expect.anything(), // retryOptions
+      EmailValidationProcessOrchestratorInput.encode({
+        email: aEmailChanged,
+        fiscalCode: aFiscalCode
+      })
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "WELCOME",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "HOWTO",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "SendWelcomeMessagesActivity",
+      someRetryOptions,
+      {
+        messageKind: "CASHBACK",
+        profile: upsertedProfileOrchestratorInput.newProfile
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "SUBSCRIBED",
+        serviceId: "service3",
+        subscriptionKind: "SERVICE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        serviceId: "service1",
+        subscriptionKind: "SERVICE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "UpdateSubscriptionsFeedActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        operation: "UNSUBSCRIBED",
+        serviceId: "service2",
+        subscriptionKind: "SERVICE",
+        updatedAt: upsertedProfileOrchestratorInput.updatedAt.getTime(),
+        version: upsertedProfileOrchestratorInput.newProfile.version
+      }
+    );
+
+    expect(contextMockWithDf.df.callActivityWithRetry).toBeCalledWith(
+      "EnqueueProfileCreationEventActivity",
+      someRetryOptions,
+      {
+        fiscalCode: aFiscalCode,
+        queueName: expectedQueueName
+      }
+    );
+  });
+});

--- a/UpsertedProfileOrchestrator/function.json
+++ b/UpsertedProfileOrchestrator/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "context",
+      "type": "orchestrationTrigger",
+      "direction": "in"
+    }
+  ],
+  "scriptFile": "../dist/UpsertedProfileOrchestrator/index.js"
+}

--- a/UpsertedProfileOrchestrator/handler.ts
+++ b/UpsertedProfileOrchestrator/handler.ts
@@ -1,0 +1,373 @@
+import * as t from "io-ts";
+
+import * as E from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
+
+import * as df from "durable-functions";
+import { IOrchestrationFunctionContext } from "durable-functions/lib/src/classes";
+
+import { UTCISODateFromString } from "@pagopa/ts-commons/lib/dates";
+import { readableReport } from "@pagopa/ts-commons/lib/reporters";
+
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
+
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
+import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
+import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
+import {
+  OrchestratorInput as EmailValidationProcessOrchestratorInput,
+  OrchestratorResult as EmailValidationProcessOrchestratorResult
+} from "../EmailValidationProcessOrchestrator/handler";
+import { Input as UpdateServiceSubscriptionFeedActivityInput } from "../UpdateSubscriptionsFeedActivity/handler";
+import { diffBlockedServices } from "../utils/profiles";
+import { EnqueueProfileCreationEventActivityInput } from "../EnqueueProfileCreationEventActivity/handler";
+import {
+  ActivityResult,
+  ActivityResultSuccess
+} from "../GetServicesPreferencesActivity/handler";
+import { ActivityInput as SendWelcomeMessageActivityInput } from "../SendWelcomeMessagesActivity/handler";
+
+/**
+ * Carries information about created or updated profile.
+ *
+ * When oldProfile is defined, the profile has been updated, or it has been
+ * created otherwise.
+ */
+export const OrchestratorInput = t.intersection([
+  t.interface({
+    newProfile: RetrievedProfile,
+    updatedAt: UTCISODateFromString
+  }),
+  t.partial({
+    oldProfile: RetrievedProfile
+  })
+]);
+
+export type OrchestratorInput = t.TypeOf<typeof OrchestratorInput>;
+
+// eslint-disable-next-line max-lines-per-function
+export const getUpsertedProfileOrchestratorHandler = (params: {
+  readonly sendCashbackMessage: boolean;
+  readonly notifyOn?: NonEmptyArray<NonEmptyString>;
+}) =>
+  // eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity
+  function*(context: IOrchestrationFunctionContext): Generator<unknown> {
+    const logPrefix = `UpsertedProfileOrchestrator`;
+
+    const retryOptions = new df.RetryOptions(5000, 10);
+    // eslint-disable-next-line functional/immutable-data
+    retryOptions.backoffCoefficient = 1.5;
+
+    // Get and decode orchestrator input
+    const input = context.df.getInput();
+    const errorOrUpsertedProfileOrchestratorInput = OrchestratorInput.decode(
+      input
+    );
+
+    if (E.isLeft(errorOrUpsertedProfileOrchestratorInput)) {
+      context.log.error(
+        `${logPrefix}|Error decoding input|ERROR=${readableReport(
+          errorOrUpsertedProfileOrchestratorInput.left
+        )}`
+      );
+      return false;
+    }
+
+    const upsertedProfileOrchestratorInput =
+      errorOrUpsertedProfileOrchestratorInput.right;
+
+    // Log the input
+    context.log.verbose(
+      `${logPrefix}|INPUT=${JSON.stringify(upsertedProfileOrchestratorInput)}`
+    );
+
+    const {
+      newProfile,
+      oldProfile,
+      updatedAt
+    } = upsertedProfileOrchestratorInput;
+
+    const profileOperation = oldProfile !== undefined ? "UPDATED" : "CREATED";
+
+    // Check if the profile email is changed
+    const isProfileEmailChanged =
+      profileOperation === "UPDATED" && newProfile.email !== oldProfile.email;
+    if (isProfileEmailChanged) {
+      try {
+        const { fiscalCode, email } = newProfile;
+
+        // Start a sub-orchestrator that handles the email validation process.
+        // From the caller point it is like a normal activity.
+        context.log.verbose(
+          `${logPrefix}|Email changed, starting the email validation process`
+        );
+        const emailValidationProcessOrchestartorInput = EmailValidationProcessOrchestratorInput.encode(
+          {
+            email,
+            fiscalCode
+          }
+        );
+
+        const emailValidationProcessOrchestartorResultJson = yield context.df.callSubOrchestratorWithRetry(
+          "EmailValidationProcessOrchestrator",
+          retryOptions,
+          emailValidationProcessOrchestartorInput
+        );
+
+        const errorOrEmailValidationProcessOrchestartorResult = EmailValidationProcessOrchestratorResult.decode(
+          emailValidationProcessOrchestartorResultJson
+        );
+
+        if (E.isLeft(errorOrEmailValidationProcessOrchestartorResult)) {
+          context.log.error(
+            `${logPrefix}|Error decoding sub-orchestrator result|ERROR=${readableReport(
+              errorOrEmailValidationProcessOrchestartorResult.left
+            )}`
+          );
+        } else {
+          const emailValidationProcessOrchestartorResult =
+            errorOrEmailValidationProcessOrchestartorResult.right;
+
+          if (emailValidationProcessOrchestartorResult.kind === "FAILURE") {
+            context.log.error(
+              `${logPrefix}|Sub-orchestrator error|ERROR=${emailValidationProcessOrchestartorResult.reason}`
+            );
+            return false;
+          }
+
+          context.log.verbose(
+            `${logPrefix}|Email verification process completed sucessfully`
+          );
+        }
+      } catch (e) {
+        context.log.error(
+          `${logPrefix}|Email verification process max retry exceeded|ERROR=${e}`
+        );
+      }
+    }
+
+    // Send welcome messages to the user
+    const isInboxEnabled = newProfile.isInboxEnabled === true;
+    const hasOldProfileWithInboxDisabled =
+      profileOperation === "UPDATED" && oldProfile.isInboxEnabled === false;
+
+    const hasJustEnabledInbox =
+      isInboxEnabled &&
+      (profileOperation === "CREATED" || hasOldProfileWithInboxDisabled);
+
+    context.log.verbose(
+      `${logPrefix}|OPERATION=${profileOperation}|INBOX_ENABLED=${isInboxEnabled}|INBOX_JUST_ENABLED=${hasJustEnabledInbox}`
+    );
+
+    if (hasJustEnabledInbox) {
+      yield context.df.callActivityWithRetry(
+        "SendWelcomeMessagesActivity",
+        retryOptions,
+        {
+          messageKind: "WELCOME",
+          profile: newProfile
+        } as SendWelcomeMessageActivityInput
+      );
+      yield context.df.callActivityWithRetry(
+        "SendWelcomeMessagesActivity",
+        retryOptions,
+        {
+          messageKind: "HOWTO",
+          profile: newProfile
+        } as SendWelcomeMessageActivityInput
+      );
+      if (params.sendCashbackMessage) {
+        yield context.df.callActivityWithRetry(
+          "SendWelcomeMessagesActivity",
+          retryOptions,
+          {
+            messageKind: "CASHBACK",
+            profile: newProfile
+          } as SendWelcomeMessageActivityInput
+        );
+      }
+    }
+
+    // Update subscriptions feed
+    if (profileOperation === "CREATED") {
+      // When a profile get created we add an entry to the profile subscriptions
+      context.log.verbose(
+        `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=SUBSCRIBED`
+      );
+      yield context.df.callActivityWithRetry(
+        "UpdateSubscriptionsFeedActivity",
+        retryOptions,
+        {
+          fiscalCode: newProfile.fiscalCode,
+          operation: "SUBSCRIBED",
+          subscriptionKind: "PROFILE",
+          updatedAt: updatedAt.getTime(),
+          version: newProfile.version
+        } as UpdateServiceSubscriptionFeedActivityInput
+      );
+    } else {
+      const { newServicePreferencesMode, oldServicePreferenceMode } = {
+        newServicePreferencesMode: newProfile.servicePreferencesSettings.mode,
+        oldServicePreferenceMode: oldProfile.servicePreferencesSettings.mode
+      };
+
+      if (newServicePreferencesMode === ServicesPreferencesModeEnum.LEGACY) {
+        // When a LEGACY profile gets updates, we extract the services that have been
+        // blocked and unblocked during this profile update.
+        // Blocked services get mapped to unsubscribe events, while unblocked ones
+        // get mapped to subscribe events.
+        const {
+          e1: unsubscribedServices,
+          e2: subscribedServices
+        } = diffBlockedServices(
+          oldProfile.blockedInboxOrChannels,
+          newProfile.blockedInboxOrChannels
+        );
+
+        for (const s of subscribedServices) {
+          context.log.verbose(
+            `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=SUBSCRIBED|SERVICE_ID=${s}`
+          );
+          yield context.df.callActivityWithRetry(
+            "UpdateSubscriptionsFeedActivity",
+            retryOptions,
+            {
+              fiscalCode: newProfile.fiscalCode,
+              operation: "SUBSCRIBED",
+              serviceId: s as ServiceId,
+              subscriptionKind: "SERVICE",
+              updatedAt: updatedAt.getTime(),
+              version: newProfile.version
+            } as UpdateServiceSubscriptionFeedActivityInput
+          );
+        }
+
+        for (const s of unsubscribedServices) {
+          context.log.verbose(
+            `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=UNSUBSCRIBED|SERVICE_ID=${s}`
+          );
+          yield context.df.callActivityWithRetry(
+            "UpdateSubscriptionsFeedActivity",
+            retryOptions,
+            {
+              fiscalCode: newProfile.fiscalCode,
+              operation: "UNSUBSCRIBED",
+              serviceId: s as ServiceId,
+              subscriptionKind: "SERVICE",
+              updatedAt: updatedAt.getTime(),
+              version: newProfile.version
+            } as UpdateServiceSubscriptionFeedActivityInput
+          );
+        }
+        // we need to update Subscription Feed on Profile Upsert when:
+        // Service Preference Mode has changed from oldProfile to newProfile in upsert operation
+        // and mode transition causes an effective change (i.e when NOT going from LEGACY to AUTO)
+      } else if (
+        oldServicePreferenceMode !== newServicePreferencesMode &&
+        (oldServicePreferenceMode !== ServicesPreferencesModeEnum.LEGACY ||
+          newServicePreferencesMode !== ServicesPreferencesModeEnum.AUTO)
+      ) {
+        // | oldServicePreferenceMode | newServicePreferencesMode | Operation
+        // -------------------------------------------------------------------------
+        // | LEGACY                   | MANUAL                    | UNSUBSCRIBED
+        // | AUTO                     | MANUAL                    | UNSUBSCRIBED
+        // | MANUAL                   | AUTO                      | SUBSCRIBED
+        // When a profile Service preference mode is upserted from AUTO or LEGACY to MANUAL
+        // we must unsubscribe th entire profile, otherwise from MANUAL we can update mode only to AUTO
+        // so we must subscribe the entire profile.
+        const feedOperation =
+          newServicePreferencesMode === ServicesPreferencesModeEnum.MANUAL
+            ? "UNSUBSCRIBED"
+            : "SUBSCRIBED";
+        context.log.verbose(
+          `${logPrefix}|Calling UpdateSubscriptionsFeedActivity|OPERATION=${feedOperation}`
+        );
+
+        // Only if previous mode is MANUAL or AUTO could exists services preferences.
+        if (
+          oldProfile.servicePreferencesSettings.mode !==
+          ServicesPreferencesModeEnum.LEGACY
+        ) {
+          // Execute a new version of the orchestrator
+          const activityResult = yield context.df.callActivityWithRetry(
+            "GetServicesPreferencesActivity",
+            retryOptions,
+            {
+              fiscalCode: oldProfile.fiscalCode,
+              settingsVersion: oldProfile.servicePreferencesSettings.version
+            }
+          );
+          const maybeServicesPreferences = pipe(
+            ActivityResult.decode(activityResult),
+            E.mapLeft(_ => new Error(readableReport(_))),
+            E.chain(
+              E.fromPredicate(
+                (_): _ is ActivityResultSuccess => _.kind === "SUCCESS",
+                _ => new Error(_.kind)
+              )
+            ),
+            E.fold(
+              err => {
+                // Invalid Activity input. The orchestration fail
+                context.log.error(
+                  `${logPrefix}|GetServicesPreferencesActivity|ERROR=${err.message}`
+                );
+                throw err;
+              },
+              _ => _.preferences
+            )
+          );
+          yield context.df.callActivityWithRetry(
+            "UpdateSubscriptionsFeedActivity",
+            retryOptions,
+            {
+              fiscalCode: newProfile.fiscalCode,
+              operation: feedOperation,
+              previousPreferences: maybeServicesPreferences,
+              subscriptionKind: "PROFILE",
+              updatedAt: updatedAt.getTime(),
+              version: newProfile.version
+            } as UpdateServiceSubscriptionFeedActivityInput
+          );
+        } else {
+          yield context.df.callActivityWithRetry(
+            "UpdateSubscriptionsFeedActivity",
+            retryOptions,
+            {
+              fiscalCode: newProfile.fiscalCode,
+              operation: feedOperation,
+              subscriptionKind: "PROFILE",
+              updatedAt: updatedAt.getTime(),
+              version: newProfile.version
+            } as UpdateServiceSubscriptionFeedActivityInput
+          );
+        }
+      }
+    }
+
+    // Create messages on specific queues when a user profile become enabled
+    // Moved at the end to mitigate orchestrator versioning https://docs.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-versioning
+    if (hasJustEnabledInbox && params.notifyOn) {
+      try {
+        yield context.df.Task.all(
+          params.notifyOn.map(serviceQueueName =>
+            context.df.callActivityWithRetry(
+              "EnqueueProfileCreationEventActivity",
+              retryOptions,
+              EnqueueProfileCreationEventActivityInput.encode({
+                fiscalCode: newProfile.fiscalCode,
+                queueName: serviceQueueName
+              })
+            )
+          )
+        );
+      } catch (e) {
+        context.log.error(
+          `${logPrefix}|Send Profile creation event max retry exeded|ERROR=${e}`
+        );
+      }
+    }
+
+    return true;
+  };

--- a/UpsertedProfileOrchestrator/index.ts
+++ b/UpsertedProfileOrchestrator/index.ts
@@ -1,0 +1,26 @@
+﻿import * as df from "durable-functions";
+import { pipe } from "fp-ts/lib/function";
+import * as NonEmptyArray from "fp-ts/lib/NonEmptyArray";
+import * as O from "fp-ts/lib/Option";
+
+import { getConfigOrThrow } from "../utils/config";
+
+import { getUpsertedProfileOrchestratorHandler } from "./handler";
+
+const config = getConfigOrThrow();
+
+const orchestrator = df.orchestrator(
+  getUpsertedProfileOrchestratorHandler({
+    notifyOn: config.FF_NEW_USERS_EUCOVIDCERT_ENABLED
+      ? pipe(
+          NonEmptyArray.fromArray([
+            config.EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME
+          ]),
+          O.getOrElseW(() => undefined)
+        )
+      : undefined,
+    sendCashbackMessage: config.IS_CASHBACK_ENABLED
+  })
+);
+
+export default orchestrator;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* Duplicate `UpsertedProfileOrchestratorV2` into `UpsertedProfileOrchestrator` in https://github.com/pagopa/io-functions-app/commit/54c9bda5ea117a91bb580259ca775e94fc45fa1d
* Replace reference to point towards newly created orchestrator in https://github.com/pagopa/io-functions-app/commit/a02c93f5d996323c37cecc760338f3854aa83c2a

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We created `UpsertedProfileOrchestratorV2` in #189 to upgrade the orchestrator algorithm without interfering with the running, not-yet-terminated instances. We're now in a stable state and we can restore correct naming. This is the first of two phases:
* deploy bot `UpsertedProfileOrchestratorV2` and `UpsertedProfileOrchestrator`, so that running instances of V2 can terminate while new instances start using the final orchestrator
* remove `UpsertedProfileOrchestratorV2` once it has no running instances (see #216)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
