### PR TITLE
[fix] One liner fix to make decoding work over io-ts 1.x bug

### DIFF
--- a/GetVisibleServices/handler.ts
+++ b/GetVisibleServices/handler.ts
@@ -72,7 +72,8 @@ export function GetVisibleServicesHandler(
                 : arr
           );
           return ResponseSuccessJson({
-            items: servicesTuples
+            items: servicesTuples,
+            prev: servicesTuples[0]?.service_id ?? "-"
           });
         }
       )


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
* added `prev` return field populated with first service id if present, else with "-".

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This field when sent allows the backend to decode the `PaginatedServiceTupleCollection` generated model also with strict generation.

You can see the bug reproduced here: https://codesandbox.io/s/laughing-mountain-z9pg5
You can see that io-ts 2.x fixes the problem here: https://codesandbox.io/s/misty-cherry-5t9j5?file=/src/index.ts

Since we cannot upgrade to io-ts 2.x yet, we have to fix this error in this way or avoid strict models (that's not suggested).

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
* yarn build
* yarn test
* yarn lint

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
