### PR TITLE
[#IP-438] Emit domain events about service subscriptions

### DIFF
--- a/CreateProfile/__tests__/handler.test.ts
+++ b/CreateProfile/__tests__/handler.test.ts
@@ -179,7 +179,7 @@ describe("CreateProfileHandler", () => {
 
     const dfClient = df.getClient(contextMock);
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "UpsertedProfileOrchestrator",
+      "UpsertedProfileOrchestratorV2",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/CreateProfile/handler.ts
+++ b/CreateProfile/handler.ts
@@ -109,7 +109,7 @@ export function CreateProfileHandler(
 
     const dfClient = df.getClient(context);
     await dfClient.startNew(
-      "UpsertedProfileOrchestrator",
+      "UpsertedProfileOrchestratorV2",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/EmitEventActivity/function.json
+++ b/EmitEventActivity/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "name": "name",
+      "type": "activityTrigger",
+      "direction": "in"
+    },
+    {
+      "queueName": "%EventsQueueName%",
+      "connection": "EventsQueueStorageConnection",
+      "name": "apievents",
+      "type": "queue",
+      "direction": "out"
+    }
+  ],
+  "scriptFile": "../dist/EmitEventActivity/index.js"
+}

--- a/EmitEventActivity/index.ts
+++ b/EmitEventActivity/index.ts
@@ -1,0 +1,10 @@
+import { Context } from "@azure/functions";
+
+/**
+ * Just an adapter to use output bindings on an Activity
+ */
+export default async (context: Context, input: unknown): Promise<void> => {
+  // eslint-disable-next-line functional/immutable-data
+  context.bindings.apievents =
+    typeof input === "string" ? input : JSON.stringify(input);
+};

--- a/UpdateProfile/__tests__/handler.test.ts
+++ b/UpdateProfile/__tests__/handler.test.ts
@@ -673,7 +673,7 @@ describe("UpdateProfileHandler", () => {
 
     const dfClient = df.getClient(contextMock);
     expect(dfClient.startNew).toHaveBeenCalledWith(
-      "UpsertedProfileOrchestrator",
+      "UpsertedProfileOrchestratorV2",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/UpdateProfile/handler.ts
+++ b/UpdateProfile/handler.ts
@@ -247,7 +247,7 @@ export function UpdateProfileHandler(
     // TODO: To enable the new orchestration change to UpsertedProfileOrchestrator
     // Change the orchestrator after that in production the code is available to enable rollback
     await dfClient.startNew(
-      "UpsertedProfileOrchestrator",
+      "UpsertedProfileOrchestratorV2",
       undefined,
       upsertedProfileOrchestratorInput
     );

--- a/UpsertServicePreferences/function.json
+++ b/UpsertServicePreferences/function.json
@@ -11,6 +11,13 @@
       ]
     },
     {
+      "queueName": "%EventsQueueName%",
+      "connection": "EventsQueueStorageConnection",
+      "name": "apievents",
+      "type": "queue",
+      "direction": "out"
+    },
+    {
       "type": "http",
       "direction": "out",
       "name": "res"

--- a/UpsertedProfileOrchestratorV2/__tests__/handler.test.ts
+++ b/UpsertedProfileOrchestratorV2/__tests__/handler.test.ts
@@ -6,7 +6,6 @@ import {
   IOrchestrationFunctionContext,
   Task
 } from "durable-functions/lib/src/classes";
-import { fromArray } from "fp-ts/lib/NonEmptyArray";
 import { context as contextMock } from "../../__mocks__/durable-functions";
 import {
   aEmailChanged,
@@ -228,7 +227,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -338,7 +336,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -453,10 +450,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(
-        fromArray([expectedQueueName]),
-        O.getOrElse(() => undefined)
-      ),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -570,7 +563,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -697,7 +689,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -846,7 +837,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -992,7 +982,6 @@ describe("UpsertedProfileOrchestrator", () => {
     };
 
     const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-      notifyOn: pipe(fromArray([expectedQueueName]), O.getOrElse(undefined)),
       sendCashbackMessage: true
     })(contextMockWithDf as any);
 
@@ -1188,7 +1177,6 @@ describe("UpsertedProfileOrchestrator |> emitted events", () => {
       } as unknown) as IOrchestrationFunctionContext;
 
       const orchestratorHandler = getUpsertedProfileOrchestratorHandler({
-        notifyOn: undefined,
         sendCashbackMessage: true
       })(mockContextWithDf);
 

--- a/UpsertedProfileOrchestratorV2/handler.ts
+++ b/UpsertedProfileOrchestratorV2/handler.ts
@@ -15,8 +15,6 @@ import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitio
 import { RetrievedProfile } from "@pagopa/io-functions-commons/dist/src/models/profile";
 
 import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
-import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
-import { NonEmptyArray } from "fp-ts/lib/NonEmptyArray";
 import {
   OrchestratorInput as EmailValidationProcessOrchestratorInput,
   OrchestratorResult as EmailValidationProcessOrchestratorResult
@@ -54,7 +52,6 @@ export type OrchestratorInput = t.TypeOf<typeof OrchestratorInput>;
 // eslint-disable-next-line max-lines-per-function
 export const getUpsertedProfileOrchestratorHandler = (params: {
   readonly sendCashbackMessage: boolean;
-  readonly notifyOn?: NonEmptyArray<NonEmptyString>;
 }) =>
   // eslint-disable-next-line max-lines-per-function, complexity, sonarjs/cognitive-complexity
   function*(context: IOrchestrationFunctionContext): Generator<unknown> {
@@ -379,8 +376,7 @@ export const getUpsertedProfileOrchestratorHandler = (params: {
             )
           : O.none
       ],
-      RA.filter(O.isSome),
-      RA.map(opt => opt.value)
+      RA.compact
     );
 
     yield context.df.Task.all(

--- a/UpsertedProfileOrchestratorV2/index.ts
+++ b/UpsertedProfileOrchestratorV2/index.ts
@@ -1,24 +1,11 @@
 ﻿import * as df from "durable-functions";
-import { pipe } from "fp-ts/lib/function";
-import * as NonEmptyArray from "fp-ts/lib/NonEmptyArray";
-import * as O from "fp-ts/lib/Option";
-
 import { getConfigOrThrow } from "../utils/config";
-
 import { getUpsertedProfileOrchestratorHandler } from "./handler";
 
 const config = getConfigOrThrow();
 
 const orchestrator = df.orchestrator(
   getUpsertedProfileOrchestratorHandler({
-    notifyOn: config.FF_NEW_USERS_EUCOVIDCERT_ENABLED
-      ? pipe(
-          NonEmptyArray.fromArray([
-            config.EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME
-          ]),
-          O.getOrElseW(() => undefined)
-        )
-      : undefined,
     sendCashbackMessage: config.IS_CASHBACK_ENABLED
   })
 );

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -76,6 +76,7 @@ export const IConfig = t.intersection([
     PUBLIC_API_URL: NonEmptyString,
 
     // eslint-disable-next-line sort-keys
+    EventsQueueName: NonEmptyString,
     EventsQueueStorageConnection: NonEmptyString,
     FN_APP_STORAGE_CONNECTION_STRING: NonEmptyString,
     MIGRATE_SERVICES_PREFERENCES_PROFILE_QUEUE_NAME: NonEmptyString,

--- a/utils/emitted_events.ts
+++ b/utils/emitted_events.ts
@@ -1,4 +1,5 @@
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
 
 interface IEvent {
@@ -12,4 +13,25 @@ export const makeServiceSubscribedEvent = (
 ): IEvent => ({
   name: `service:subscribed`,
   payload: { fiscalCode, serviceId }
+});
+
+export const makeProfileCompletedEvent = (
+  fiscalCode: FiscalCode,
+  servicePreferencesMode: ServicesPreferencesModeEnum
+): IEvent => ({
+  name: `profile:completed`,
+  payload: { fiscalCode, servicePreferencesMode }
+});
+
+export const makeServicePreferencesChangedEvent = (
+  fiscalCode: FiscalCode,
+  servicePreferencesMode: ServicesPreferencesModeEnum,
+  oldServicePreferencesMode: ServicesPreferencesModeEnum
+): IEvent => ({
+  name: `profile:service-preferences-changed`,
+  payload: {
+    fiscalCode,
+    oldServicePreferencesMode,
+    servicePreferencesMode
+  }
 });

--- a/utils/emitted_events.ts
+++ b/utils/emitted_events.ts
@@ -1,0 +1,15 @@
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { FiscalCode } from "@pagopa/ts-commons/lib/strings";
+
+interface IEvent {
+  readonly name: string;
+  readonly payload: Record<string, unknown>;
+}
+
+export const makeServiceSubscribedEvent = (
+  serviceId: ServiceId,
+  fiscalCode: FiscalCode
+): IEvent => ({
+  name: `service:subscribed`,
+  payload: { fiscalCode, serviceId }
+});


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to emit events about how a Citizen updates their subscriptions to services. With this PR, the following events will be emitted:
* `profile:completed`
* `profile:service-preferences-changed`
* `service:subscribed`

At the same time, we no longer publish messages on `EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME` as the mechanism will be replaced by the webhook mechanism introduced in https://github.com/pagopa/io-functions-public-event-dispatcher

#### List of Changes
<!--- Describe your changes in detail -->
* emit `service:subscribed` on service preference update
* emit `profile:completed` and `profile:service-preferences-changed` on profile update
* remove notification on `EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME`


#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Unit tests

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
