### PR TITLE
[#IC-44] Add support for Special Services

### DIFF
--- a/GetServicePreferences/__tests__/handler.test.ts
+++ b/GetServicePreferences/__tests__/handler.test.ts
@@ -47,6 +47,9 @@ const serviceModelMock = {
 };
 
 describe("GetServicePreferences", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   it("should return existing service preference for user", async () => {
     const profileModelMock = {
       findLastVersionByModelId: jest.fn(() => {

--- a/GetServicePreferences/handler.ts
+++ b/GetServicePreferences/handler.ts
@@ -39,7 +39,7 @@ import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/servi
 import { ServiceCategory } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceCategory";
 import { SpecialServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/SpecialServiceCategory";
 import { ActivationModel } from "@pagopa/io-functions-commons/dist/src/models/activation";
-import { StandardServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/StandardServiceCategory";
+import { getServiceCategoryOrStandard } from "../utils/services";
 import {
   getServicePreferenceSettingsVersion,
   getServicePreferencesForSpecialServices,
@@ -167,9 +167,7 @@ export const GetServicePreferencesHandler = (
           TE.map(version => ({
             fiscalCode,
             mode: profile.servicePreferencesSettings.mode,
-            serviceCategory: service.serviceMetadata
-              ? service.serviceMetadata.category
-              : StandardServiceCategoryEnum.STANDARD,
+            serviceCategory: getServiceCategoryOrStandard(service),
             serviceId,
             version
           }))

--- a/GetServicePreferences/index.ts
+++ b/GetServicePreferences/index.ts
@@ -13,6 +13,14 @@ import {
 import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/express";
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
+import {
+  ServiceModel,
+  SERVICE_COLLECTION_NAME
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import {
+  ActivationModel,
+  ACTIVATION_COLLECTION_NAME
+} from "@pagopa/io-functions-commons/dist/src/models/activation";
 import { cosmosdbInstance } from "../utils/cosmosdb";
 
 import { GetServicePreferences } from "./handler";
@@ -30,9 +38,22 @@ const servicePreferencesModel = new ServicesPreferencesModel(
   SERVICE_PREFERENCES_COLLECTION_NAME
 );
 
+const serviceModel = new ServiceModel(
+  cosmosdbInstance.container(SERVICE_COLLECTION_NAME)
+);
+
+const activationModel = new ActivationModel(
+  cosmosdbInstance.container(ACTIVATION_COLLECTION_NAME)
+);
+
 app.get(
   "/api/v1/profiles/:fiscalcode/services/:serviceId/preferences",
-  GetServicePreferences(profileModel, servicePreferencesModel)
+  GetServicePreferences(
+    profileModel,
+    serviceModel,
+    servicePreferencesModel,
+    activationModel
+  )
 );
 
 const azureFunctionHandler = createAzureFunctionHandler(app);

--- a/GetVisibleServices/__tests__/handler.test.ts
+++ b/GetVisibleServices/__tests__/handler.test.ts
@@ -28,6 +28,7 @@ import { ServiceScopeEnum } from "@pagopa/io-functions-commons/dist/generated/de
 import { IResponseSuccessJson } from "@pagopa/ts-commons/lib/responses";
 import { aCosmosResourceMetadata } from "../../__mocks__/mocks";
 import { GetVisibleServices, GetVisibleServicesHandler } from "../handler";
+import { StandardServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/StandardServiceCategory";
 
 afterEach(() => {
   jest.resetAllMocks();
@@ -77,7 +78,9 @@ const aVisibleService: VisibleService = {
 const aLocalVisibleService: VisibleService = {
   ...aVisibleService,
   serviceMetadata: {
-    scope: ServiceScopeEnum.LOCAL
+    scope: ServiceScopeEnum.LOCAL,
+    category: StandardServiceCategoryEnum.STANDARD,
+    customSpecialFlow: undefined
   }
 };
 

--- a/UpsertServicePreferences/handler.ts
+++ b/UpsertServicePreferences/handler.ts
@@ -47,7 +47,7 @@ import { NonEmptyString } from "@pagopa/ts-commons/lib/strings";
 import { TableService } from "azure-storage";
 import { ActivationModel } from "@pagopa/io-functions-commons/dist/src/models/activation";
 import { SpecialServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/SpecialServiceCategory";
-import { StandardServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/StandardServiceCategory";
+import { getServiceCategoryOrStandard } from "../utils/services";
 import {
   getServicePreferenceSettingsVersion,
   getServicePreferencesForSpecialServices,
@@ -206,9 +206,7 @@ export const GetUpsertServicePreferencesHandler = (
           ),
           TE.map(version => ({
             fiscalCode,
-            serviceCategory:
-              service.serviceMetadata?.category ||
-              StandardServiceCategoryEnum.STANDARD,
+            serviceCategory: getServiceCategoryOrStandard(service),
             serviceId,
             servicePreferencesToUpsert: servicePreference,
             version

--- a/UpsertServicePreferences/handler.ts
+++ b/UpsertServicePreferences/handler.ts
@@ -21,14 +21,8 @@ import {
   ResponseErrorQuery
 } from "@pagopa/io-functions-commons/dist/src/utils/response";
 
-import {
-  Profile,
-  ProfileModel
-} from "@pagopa/io-functions-commons/dist/src/models/profile";
-import {
-  Service,
-  ServiceModel
-} from "@pagopa/io-functions-commons/dist/src/models/service";
+import { ProfileModel } from "@pagopa/io-functions-commons/dist/src/models/profile";
+import { ServiceModel } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
   makeServicesPreferencesDocumentId,
   ServicesPreferencesModel
@@ -40,7 +34,6 @@ import {
   IResponseErrorNotFound,
   IResponseSuccessJson,
   ResponseErrorConflict,
-  ResponseErrorNotFound,
   ResponseSuccessJson
 } from "@pagopa/ts-commons/lib/responses";
 
@@ -59,6 +52,8 @@ import {
 } from "../utils/service_preferences";
 import { createTracker } from "../utils/tracking";
 import { makeServiceSubscribedEvent } from "../utils/emitted_events";
+import { getProfileOrErrorResponse } from "../utils/profiles";
+import { getServiceOrErrorResponse } from "../utils/services";
 import { updateSubscriptionFeedTask } from "./subscription_feed";
 
 enum FeedOperationEnum {
@@ -91,48 +86,6 @@ type IUpsertServicePreferencesHandler = (
   serviceId: ServiceId,
   servicePreference: ServicePreference
 ) => Promise<IUpsertServicePreferencesHandlerResult>;
-
-/**
- * Return a task containing either an error or the required Profile
- */
-const getProfileOrErrorResponse = (profileModels: ProfileModel) => (
-  fiscalCode: FiscalCode
-): TE.TaskEither<IResponseErrorQuery | IResponseErrorNotFound, Profile> =>
-  pipe(
-    profileModels.findLastVersionByModelId([fiscalCode]),
-    TE.mapLeft(failure =>
-      ResponseErrorQuery("Error while retrieving the profile", failure)
-    ),
-    TE.chainW(
-      TE.fromOption(() =>
-        ResponseErrorNotFound(
-          "Profile not found",
-          "The profile you requested was not found in the system."
-        )
-      )
-    )
-  );
-
-/**
- * Return a task containing either an error or the required Service
- */
-const getServiceOrErrorResponse = (serviceModel: ServiceModel) => (
-  serviceId: ServiceId
-): TE.TaskEither<IResponseErrorQuery | IResponseErrorNotFound, Service> =>
-  pipe(
-    serviceModel.findLastVersionByModelId([serviceId]),
-    TE.mapLeft(failure =>
-      ResponseErrorQuery("Error while retrieving the service", failure)
-    ),
-    TE.chainW(
-      TE.fromOption(() =>
-        ResponseErrorNotFound(
-          "Service not found",
-          "The service you requested was not found in the system."
-        )
-      )
-    )
-  );
 
 /**
  * Return a function that returns the service preference for the

--- a/UpsertServicePreferences/index.ts
+++ b/UpsertServicePreferences/index.ts
@@ -18,6 +18,10 @@ import { secureExpressApp } from "@pagopa/io-functions-commons/dist/src/utils/ex
 import { setAppContext } from "@pagopa/io-functions-commons/dist/src/utils/middlewares/context_middleware";
 
 import { createTableService } from "azure-storage";
+import {
+  ActivationModel,
+  ACTIVATION_COLLECTION_NAME
+} from "@pagopa/io-functions-commons/dist/src/models/activation";
 import { initTelemetryClient } from "../utils/appinsights";
 import { getConfigOrThrow } from "../utils/config";
 import { cosmosdbInstance } from "../utils/cosmosdb";
@@ -41,6 +45,10 @@ const servicePreferencesModel = new ServicesPreferencesModel(
   SERVICE_PREFERENCES_COLLECTION_NAME
 );
 
+const activationModel = new ActivationModel(
+  cosmosdbInstance.container(ACTIVATION_COLLECTION_NAME)
+);
+
 const tableService = createTableService(config.QueueStorageConnection);
 app.post(
   "/api/v1/profiles/:fiscalcode/services/:serviceId/preferences",
@@ -49,6 +57,7 @@ app.post(
     profileModel,
     serviceModel,
     servicePreferencesModel,
+    activationModel,
     tableService,
     config.SUBSCRIPTIONS_FEED_TABLE
   )

--- a/__mocks__/mocks.service_preference.ts
+++ b/__mocks__/mocks.service_preference.ts
@@ -1,5 +1,7 @@
+import { ActivationStatusEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ActivationStatus";
 import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
 import { ServicePreference } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicePreference";
+import { Activation } from "@pagopa/io-functions-commons/dist/src/models/activation";
 import { RetrievedService } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
   makeServicesPreferencesDocumentId,
@@ -41,3 +43,10 @@ export const aRetrievedService: RetrievedService = ({
   serviceName: "a Service",
   organizationName: "a Organization"
 } as any) as RetrievedService;
+
+export const anActiveActivation: Activation = {
+  ...aCosmosResourceMetadata,
+  fiscalCode: aFiscalCode,
+  serviceId: aServiceId,
+  status: ActivationStatusEnum.ACTIVE
+};

--- a/__mocks__/mocks.service_preference.ts
+++ b/__mocks__/mocks.service_preference.ts
@@ -5,6 +5,7 @@ import { Activation } from "@pagopa/io-functions-commons/dist/src/models/activat
 import { RetrievedService } from "@pagopa/io-functions-commons/dist/src/models/service";
 import {
   makeServicesPreferencesDocumentId,
+  NewServicePreference,
   RetrievedServicePreference
 } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
@@ -13,20 +14,24 @@ import { aCosmosResourceMetadata, aFiscalCode } from "./mocks";
 export const aServiceId = "aServiceId" as ServiceId;
 export const aServicePreferenceVersion = 0 as NonNegativeInteger;
 
-export const aRetrievedServicePreference: RetrievedServicePreference = {
-  ...aCosmosResourceMetadata,
+export const aNewServicePreference: NewServicePreference = {
   isEmailEnabled: true,
   isInboxEnabled: true,
   isWebhookEnabled: true,
   settingsVersion: aServicePreferenceVersion,
   fiscalCode: aFiscalCode,
   serviceId: aServiceId,
-  kind: "IRetrievedServicePreference",
+  kind: "INewServicePreference",
   id: makeServicesPreferencesDocumentId(
     aFiscalCode,
     aServiceId,
     aServicePreferenceVersion
   )
+};
+export const aRetrievedServicePreference: RetrievedServicePreference = {
+  ...aCosmosResourceMetadata,
+  ...aNewServicePreference,
+  kind: "IRetrievedServicePreference"
 };
 
 export const aServicePreference: ServicePreference = {

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -600,38 +600,13 @@ definitions:
     allOf:
       - $ref: '#/definitions/VisibleServicePayload'
       - $ref: '#/definitions/HiddenServicePayload'
-  HiddenServicePayload:
-    description: A payload used to create/update a service that is hidden.
+  ExtendedServicePayload:
     allOf:
-      - $ref: '#/definitions/CommonServicePayload'
+      - $ref: '#/definitions/ServicePayload'
       - type: object
         properties:
-          is_visible:
-            type: boolean
-            default: false
-            enum:
-              - false
-            description: It indicates that service is hidden
           service_metadata:
             $ref: '#/definitions/ServiceMetadata'
-  VisibleServicePayload:
-    description: >-
-      A payload used to create/update a service that appears in the service
-      list.
-    allOf:
-      - $ref: '#/definitions/CommonServicePayload'
-      - type: object
-        properties:
-          is_visible:
-            type: boolean
-            enum:
-              - true
-            description: It indicates that service appears in the service list
-          service_metadata:
-            $ref: '#/definitions/ServiceMetadata'
-        required:
-          - is_visible
-          - service_metadata
   CommonServicePayload:
     description: Common properties for a ServicePayload
     type: object
@@ -665,6 +640,44 @@ definitions:
       - organization_name
       - organization_fiscal_code
       - authorized_cidrs
+  HiddenServicePayload:
+    description: A payload used to create/update a service that is hidden.
+    allOf:
+      - $ref: '#/definitions/CommonServicePayload'
+      - type: object
+        properties:
+          is_visible:
+            type: boolean
+            default: false
+            enum:
+              - false
+            description: It indicates that service is hidden
+          service_metadata:
+            description: >-
+              That service can't handle some ServiceMetadata fields (es.
+              category)
+            $ref: '#/definitions/CommonServiceMetadata'
+  VisibleServicePayload:
+    description: >-
+      A payload used to create/update a service that appears in the service
+      list.
+    allOf:
+      - $ref: '#/definitions/CommonServicePayload'
+      - type: object
+        properties:
+          is_visible:
+            type: boolean
+            enum:
+              - true
+            description: It indicates that service appears in the service list
+          service_metadata:
+            description: >-
+              That service can't handle some ServiceMetadata fields (es.
+              category)
+            $ref: '#/definitions/CommonServiceMetadata'
+        required:
+          - is_visible
+          - service_metadata
   OrganizationName:
     type: string
     description: |-
@@ -912,6 +925,33 @@ definitions:
       API user.
     minLength: 1
   ServiceMetadata:
+    x-one-of: true
+    allOf:
+      - $ref: '#/definitions/StandardServiceMetadata'
+      - $ref: '#/definitions/SpecialServiceMetadata'
+      - $ref: '#/definitions/CommonServiceMetadata'
+  StandardServiceMetadata:
+    allOf:
+      - $ref: '#/definitions/CommonServiceMetadata'
+      - type: object
+        properties:
+          category:
+            $ref: '#/definitions/StandardServiceCategory'
+        required:
+          - category
+  SpecialServiceMetadata:
+    allOf:
+      - $ref: '#/definitions/CommonServiceMetadata'
+      - type: object
+        properties:
+          category:
+            $ref: '#/definitions/SpecialServiceCategory'
+          custom_special_flow:
+            type: string
+            minLength: 1
+        required:
+          - category
+  CommonServiceMetadata:
     type: object
     description: A set of metadata properties related to this service.
     properties:
@@ -958,6 +998,19 @@ definitions:
         $ref: '#/definitions/ServiceScope'
     required:
       - scope
+  SpecialServiceCategory:
+    type: string
+    x-extensible-enum:
+      - SPECIAL
+  StandardServiceCategory:
+    type: string
+    x-extensible-enum:
+      - STANDARD
+  ServiceCategory:
+    x-one-of: true
+    allOf:
+      - $ref: '#/definitions/SpecialServiceCategory'
+      - $ref: '#/definitions/StandardServiceCategory'
   ServiceScope:
     type: string
     x-extensible-enum:

--- a/openapi/index.yaml.template
+++ b/openapi/index.yaml.template
@@ -524,12 +524,14 @@ definitions:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/CIDR"
   ServicePayload:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/ServicePayload"
+  ExtendedServicePayload:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/ExtendedServicePayload"
+  CommonServicePayload:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/CommonServicePayload"
   HiddenServicePayload:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/HiddenServicePayload"
   VisibleServicePayload:
-    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/VisibleServicePayload"   
-  CommonServicePayload:
-    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/CommonServicePayload"
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/VisibleServicePayload"
   OrganizationName:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/OrganizationName"
   DepartmentName:
@@ -562,6 +564,18 @@ definitions:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/ServiceId"
   ServiceMetadata:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/ServiceMetadata"
+  StandardServiceMetadata:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/StandardServiceMetadata"
+  SpecialServiceMetadata:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/SpecialServiceMetadata"
+  CommonServiceMetadata:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/CommonServiceMetadata"
+  SpecialServiceCategory:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/SpecialServiceCategory"
+  StandardServiceCategory:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/StandardServiceCategory"
+  ServiceCategory:
+    $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/ServiceCategory"
   ServiceScope:
     $ref: "../node_modules/@pagopa/io-functions-commons/openapi/definitions.yaml#/ServiceScope"
   ServiceName:

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@azure/cosmos": "^3.11.5",
     "@azure/storage-queue": "^12.4.0",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^21.7.3",
+    "@pagopa/io-functions-commons": "../io-functions-commons",
     "@pagopa/ts-commons": "^10.1.0",
     "abort-controller": "^3.0.0",
     "applicationinsights": "^1.8.10",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@azure/cosmos": "^3.11.5",
     "@azure/storage-queue": "^12.4.0",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "../io-functions-commons",
+    "@pagopa/io-functions-commons": "^22.0.1",
     "@pagopa/ts-commons": "^10.1.0",
     "abort-controller": "^3.0.0",
     "applicationinsights": "^1.8.10",

--- a/utils/service_preferences.ts
+++ b/utils/service_preferences.ts
@@ -1,11 +1,20 @@
 import { pipe } from "fp-ts/lib/function";
 import * as TE from "fp-ts/lib/TaskEither";
+import * as O from "fp-ts/lib/Option";
 
 import { ServicePreference } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicePreference";
 import { ServicesPreferencesModeEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ServicesPreferencesMode";
 import { Profile } from "@pagopa/io-functions-commons/dist/src/models/profile";
 import { RetrievedServicePreference } from "@pagopa/io-functions-commons/dist/src/models/service_preference";
 import { NonNegativeInteger } from "@pagopa/ts-commons/lib/numbers";
+import { ServiceId } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceId";
+import { FiscalCode } from "@pagopa/io-functions-commons/dist/generated/definitions/FiscalCode";
+import {
+  IResponseErrorQuery,
+  ResponseErrorQuery
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
+import { ActivationModel } from "@pagopa/io-functions-commons/dist/src/models/activation";
+import { ActivationStatusEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/ActivationStatus";
 
 const toUserServicePreference = (
   emailEnabled: boolean,
@@ -88,3 +97,36 @@ export function getServicePreferenceSettingsVersion(
     TE.mapLeft(_ => Error("Service Preferences Version < 0 not allowed"))
   );
 }
+
+export type ServicePreferencesForSpecialServices = (params: {
+  readonly serviceId: ServiceId;
+  readonly fiscalCode: FiscalCode;
+  readonly servicePreferences: ServicePreference;
+}) => TE.TaskEither<IResponseErrorQuery, ServicePreference>;
+
+export const getServicePreferencesForSpecialServices = (
+  activationModel: ActivationModel
+): ServicePreferencesForSpecialServices => ({
+  serviceId,
+  fiscalCode,
+  servicePreferences
+}): TE.TaskEither<IResponseErrorQuery, ServicePreference> =>
+  pipe(
+    activationModel.findLastVersionByModelId([serviceId, fiscalCode]),
+    TE.mapLeft(err =>
+      ResponseErrorQuery("Error reading service Activation", err)
+    ),
+    TE.map(_ => {
+      if (O.isNone(_) || _.value.status !== ActivationStatusEnum.ACTIVE) {
+        // When the Activation is missing the default value is INACTIVE.
+        return {
+          ...servicePreferences,
+          is_inbox_enabled: false
+        };
+      }
+      return {
+        ...servicePreferences,
+        is_inbox_enabled: true
+      };
+    })
+  );

--- a/utils/services.ts
+++ b/utils/services.ts
@@ -1,3 +1,5 @@
+import { ServiceCategory } from "@pagopa/io-functions-commons/dist/generated/definitions/ServiceCategory";
+import { StandardServiceCategoryEnum } from "@pagopa/io-functions-commons/dist/generated/definitions/StandardServiceCategory";
 import {
   ServiceModel,
   Service
@@ -34,3 +36,15 @@ export const getServiceOrErrorResponse = (serviceModel: ServiceModel) => (
       )
     )
   );
+
+/**
+ * Returns the Service Category from a Service.
+ * If serviceMetadata are not defined the default value STANDARD is returned.
+ *
+ * @param service
+ * @returns ServiceCategory or StandardServiceCategoryEnum.STANDARD
+ */
+export const getServiceCategoryOrStandard = (
+  service: Service
+): ServiceCategory =>
+  service.serviceMetadata?.category || StandardServiceCategoryEnum.STANDARD;

--- a/utils/services.ts
+++ b/utils/services.ts
@@ -1,0 +1,36 @@
+import {
+  ServiceModel,
+  Service
+} from "@pagopa/io-functions-commons/dist/src/models/service";
+import {
+  IResponseErrorQuery,
+  ResponseErrorQuery
+} from "@pagopa/io-functions-commons/dist/src/utils/response";
+import {
+  IResponseErrorNotFound,
+  ResponseErrorNotFound
+} from "@pagopa/ts-commons/lib/responses";
+import { pipe } from "fp-ts/lib/function";
+import * as TE from "fp-ts/TaskEither";
+import { ServiceId } from "../generated/backend/ServiceId";
+
+/**
+ * Return a task containing either an error or the required Service
+ */
+export const getServiceOrErrorResponse = (serviceModel: ServiceModel) => (
+  serviceId: ServiceId
+): TE.TaskEither<IResponseErrorQuery | IResponseErrorNotFound, Service> =>
+  pipe(
+    serviceModel.findLastVersionByModelId([serviceId]),
+    TE.mapLeft(failure =>
+      ResponseErrorQuery("Error while retrieving the service", failure)
+    ),
+    TE.chainW(
+      TE.fromOption(() =>
+        ResponseErrorNotFound(
+          "Service not found",
+          "The service you requested was not found in the system."
+        )
+      )
+    )
+  );

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,8 +709,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@../io-functions-commons":
-  version "21.8.0"
+"@pagopa/io-functions-commons@^22.0.1":
+  version "22.0.1"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-22.0.1.tgz#332243e405c29db4862780135525f968c667da47"
+  integrity sha512-9ZQ1N8PEZkSsceiP2SG2lTsO+sQxJG0QZpCPVjK/ulpkF0RSqiaFufTzUaSXxiNkaUMd+mYaeo92vfg2GWqxaA==
   dependencies:
     "@azure/cosmos" "^3.11.5"
     "@pagopa/ts-commons" "^10.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,15 +709,13 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^21.7.3":
-  version "21.7.3"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-21.7.3.tgz#dcbd9eed077ae437fefc61986d0f49758b5dedca"
-  integrity sha512-RdP+np8Ly/7qI/B9JWRHKMFar2cKTGDdiJaWgZerJHcVSZUhnrR5XOgqlSoQs7Dt3cL2to9fLKeE9bDO7K1eXA==
+"@pagopa/io-functions-commons@../io-functions-commons":
+  version "21.8.0"
   dependencies:
     "@azure/cosmos" "^3.11.5"
     "@pagopa/ts-commons" "^10.0.1"
     applicationinsights "^1.8.10"
-    azure-storage "^2.10.4"
+    azure-storage "^2.10.5"
     cidr-matcher "^2.1.1"
     fp-ts "^2.10.5"
     helmet "^4.6.0"
@@ -1589,7 +1587,7 @@ axios@^0.21.1:
   dependencies:
     follow-redirects "^1.14.0"
 
-azure-storage@^2.10.3, azure-storage@^2.10.4:
+azure-storage@^2.10.3:
   version "2.10.4"
   resolved "https://registry.yarnpkg.com/azure-storage/-/azure-storage-2.10.4.tgz#c481d207eabc05f57f019b209f7faa8737435104"
   integrity sha512-zlfRPl4js92JC6+79C2EUmNGYjSknRl8pOiHQF78zy+pbOFOHtlBF6BU/OxPeHQX3gaa6NdEZnVydFxhhndkEw==
@@ -1603,6 +1601,23 @@ azure-storage@^2.10.3, azure-storage@^2.10.4:
     underscore "^1.12.1"
     uuid "^3.0.0"
     validator "~9.4.1"
+    xml2js "0.2.8"
+    xmlbuilder "^9.0.7"
+
+azure-storage@^2.10.5:
+  version "2.10.5"
+  resolved "https://registry.yarnpkg.com/azure-storage/-/azure-storage-2.10.5.tgz#2193314940954c8e90c14d0601fb146470740f70"
+  integrity sha512-kLCbiW1lvwwJwB/iOX7ic7xw/RIcSReF1sUFetEyFSiE+HDdv/wpSlsQx0F0khkXrPtJmBJRH0y9s/CRuRBWLQ==
+  dependencies:
+    browserify-mime "~1.2.9"
+    extend "^3.0.2"
+    json-edm-parser "0.1.2"
+    md5.js "1.3.4"
+    readable-stream "~2.0.0"
+    request "^2.86.0"
+    underscore "^1.12.1"
+    uuid "^3.0.0"
+    validator "~13.6.0"
     xml2js "0.2.8"
     xmlbuilder "^9.0.7"
 
@@ -8999,7 +9014,7 @@ validator@^10.1.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
   integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
 
-validator@^13.6.0:
+validator@^13.6.0, validator@~13.6.0:
   version "13.6.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.6.0.tgz#1e71899c14cdc7b2068463cb24c1cc16f6ec7059"
   integrity sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg==


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Upgrade `io-functions-commons` library
Upgrade `index.yaml.template` type definitions
`GetServicePreferences` for special services replace `is_inbox_enabled` value with the `Activation` status (`true` for `ACTIVE` status, `false` otherwise)
`UpsertServicePreferences` for special services check the `Activation` status, the provided `is_inbox_enabled` must be consistent with the current `Activation` status (`true` for `ACTIVE` status, `false` otherwise)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to upgrade the type definitions from `io-functions-commons` to properly handle new SpecialServices.
The API's to interact with service prerences must consider `Activation` for special services.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
