### PR TITLE
[#IC-206] Enable multi-provider for Legal Message

### DIFF
--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -1483,8 +1483,7 @@ definitions:
         type: string
         minLength: 1
       pec_server_service_id:
-        type: string
-        minLength: 1
+        $ref: '#/definitions/ServiceId'
     required:
       - sender_mail_from
       - has_attachment

--- a/openapi/index.yaml
+++ b/openapi/index.yaml
@@ -1482,6 +1482,9 @@ definitions:
       original_message_url:
         type: string
         minLength: 1
+      pec_server_service_id:
+        type: string
+        minLength: 1
     required:
       - sender_mail_from
       - has_attachment

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@azure/cosmos": "^3.11.5",
     "@azure/storage-queue": "^12.4.0",
     "@pagopa/express-azure-functions": "^2.0.0",
-    "@pagopa/io-functions-commons": "^22.5.0",
+    "@pagopa/io-functions-commons": "^22.7.0",
     "@pagopa/ts-commons": "^10.1.0",
     "abort-controller": "^3.0.0",
     "applicationinsights": "^1.8.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,10 +709,10 @@
   resolved "https://registry.yarnpkg.com/@pagopa/express-azure-functions/-/express-azure-functions-2.0.0.tgz#eb52a0b997d931c1509372e2a9bea22a8ca85c17"
   integrity sha512-IFZqtk0e2sfkMZIxYqPORzxcKRkbIrVJesR6eMLNwzh1rA4bl2uh9ZHk1m55LNq4ZmaxREDu+1JcGlIaZQgKNQ==
 
-"@pagopa/io-functions-commons@^22.5.0":
-  version "22.5.0"
-  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-22.5.0.tgz#89491deb779f20772d8d5b4b72602bc805940baf"
-  integrity sha512-rQy9Il6YIONam5GtzgEb2s8YqT3fAlXrSTGwjKonRsD0r6MtWS7yq4zGFFQd5QzZ03o+aWzEyvP27L32rwfIwA==
+"@pagopa/io-functions-commons@^22.7.0":
+  version "22.7.0"
+  resolved "https://registry.yarnpkg.com/@pagopa/io-functions-commons/-/io-functions-commons-22.7.0.tgz#83de411c059788f0849a0702440c377c0e3b4d48"
+  integrity sha512-g61+FqrzM6WTEgoZWnWe4vHANdbMleHvlAoS3YiI8Rl0apP9C3nWu1v9XXjloqM2TX01ewnVPEd7F2ozKBAO5Q==
   dependencies:
     "@azure/cosmos" "^3.11.5"
     "@pagopa/ts-commons" "^10.0.1"


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
The Legal Message could be sent to IO by different PEC-SERVER. IO-APP must return the stored PEC-SERVER sender ID in order to properly manage message nerichment.

#### List of Changes
<!--- Describe your changes in detail -->
add sender service id to  LegalData message model.

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Properly retrieve the pec-server id of the legal message sender without relying on external input

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
unit test

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
