### PR TITLE
[#IOPID-2334] `FF_NEW_USERS_EUCOVIDCERT_ENABLED` removal

### DIFF
--- a/__mocks__/env-config.mock.ts
+++ b/__mocks__/env-config.mock.ts
@@ -29,7 +29,6 @@ export const envConfig = ({
   OPT_OUT_EMAIL_SWITCH_DATE: ("1577836800000" as unknown) as DateFromTimestamp,
 
   IS_CASHBACK_ENABLED: true,
-  FF_NEW_USERS_EUCOVIDCERT_ENABLED: true,
   FF_ONLY_NATIONAL_SERVICES: true,
   FF_OPT_IN_EMAIL_ENABLED: true,
 

--- a/env.example
+++ b/env.example
@@ -30,8 +30,6 @@ AZURE_ENABLE_STRICT_SSL=false
 REQ_SERVICE_ID=req_id_dev
 MIGRATE_SERVICES_PREFERENCES_PROFILE_QUEUE_NAME=profile-migrate-services-preferences-from-legacy
 
-EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME=eucovidcert-profile-created
-
 EventsQueueName=events
 
 COSMOSDB_URI=https://cosmosdb:3000/

--- a/env.example
+++ b/env.example
@@ -31,7 +31,6 @@ REQ_SERVICE_ID=req_id_dev
 MIGRATE_SERVICES_PREFERENCES_PROFILE_QUEUE_NAME=profile-migrate-services-preferences-from-legacy
 
 EUCOVIDCERT_PROFILE_CREATED_QUEUE_NAME=eucovidcert-profile-created
-FF_NEW_USERS_EUCOVIDCERT_ENABLED=true
 
 EventsQueueName=events
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -123,7 +123,6 @@ export const IConfig = t.intersection([
     IS_CASHBACK_ENABLED: t.boolean,
 
     // eslint-disable-next-line sort-keys
-    FF_NEW_USERS_EUCOVIDCERT_ENABLED: t.boolean,
     FF_ONLY_NATIONAL_SERVICES: t.boolean,
     FF_OPT_IN_EMAIL_ENABLED: t.boolean,
     FF_TEMPLATE_EMAIL: FeatureFlagFromString,
@@ -155,9 +154,6 @@ const getBooleanOrFalse = (value?: string) =>
 // No need to re-evaluate this object for each call
 const errorOrConfig: t.Validation<IConfig> = IConfig.decode({
   ...process.env,
-  FF_NEW_USERS_EUCOVIDCERT_ENABLED: getBooleanOrFalse(
-    process.env.FF_NEW_USERS_EUCOVIDCERT_ENABLED
-  ),
   FF_ONLY_NATIONAL_SERVICES: getBooleanOrFalse(
     process.env.FF_ONLY_NATIONAL_SERVICES
   ),


### PR DESCRIPTION
### This PR depends on https://github.com/pagopa/io-functions-app/pull/317 for lint rules being fixed there.
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Remove `FF_NEW_USERS_EUCOVIDCERT_ENABLED`.

#### Motivation and Context
The Feature Flag is no longer needed.

#### How Has This Been Tested?
Unit tests.

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Chore (nothing changes by a user perspective)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
